### PR TITLE
refactor: centralize player editor paths

### DIFF
--- a/app/app_paths.py
+++ b/app/app_paths.py
@@ -20,14 +20,23 @@ DATA_DIR.mkdir(parents=True, exist_ok=True)
 def file_path(name: str) -> Path:
     return DATA_DIR / name
 
+# Predefined file paths and directories
+PLAYERS_FP = file_path("players.json")
+MATCHES_FP = file_path("matches.json")
+SCOUT_REPORTS_FP = file_path("scout_reports.json")
+SHORTLISTS_FP = file_path("shortlists.json")
+NOTES_FP = file_path("notes.json")
+
+PLAYER_PHOTOS_DIR = DATA_DIR / "player_photos"
+PLAYER_PHOTOS_DIR.mkdir(parents=True, exist_ok=True)
+
 # Luo oletustiedostot jos puuttuu (turvallinen ajaa aina)
-for fname, default in [
-    ("players.json", []),
-    ("matches.json", []),
-    ("scout_reports.json", []),
-    ("shortlists.json", {}),
-    ("notes.json", [])
+for fp, default in [
+    (PLAYERS_FP, []),
+    (MATCHES_FP, []),
+    (SCOUT_REPORTS_FP, []),
+    (SHORTLISTS_FP, {}),
+    (NOTES_FP, [])
 ]:
-    fp = file_path(fname)
     if not fp.exists():
         fp.write_text(json.dumps(default), encoding="utf-8")

--- a/app/player_editor.py
+++ b/app/player_editor.py
@@ -14,7 +14,7 @@ from storage import Storage
 storage = Storage()
 
 # --- projektin apurit ---
-from app_paths import file_path, DATA_DIR
+from app_paths import DATA_DIR, PLAYERS_FP, SHORTLISTS_FP, PLAYER_PHOTOS_DIR
 from data_utils import (
     list_teams, load_master, save_master,
     load_seasonal_stats, save_seasonal_stats, BASE_DIR,
@@ -25,8 +25,6 @@ from data_utils import (
 # Polut
 # -------------------------------------------------------
 # Huom: PLAYERS_FP ei ole enää välttämätön storagen kanssa, mutta pidetään polut yhtenäisinä
-PLAYERS_FP    = file_path("players.json")
-SHORTLISTS_FP = file_path("shortlists.json")
 
 # -------------------------------------------------------
 # Yleiset apurit
@@ -233,11 +231,10 @@ def remove_from_players_storage_by_ids(ids: List[str]) -> int:
     return storage.remove_by_ids([str(x) for x in ids])
 
 def _save_photo_and_link_storage(player_id: str, filename: str, content: bytes) -> Path:
-    photos_dir = DATA_DIR / "player_photos"
-    photos_dir.mkdir(parents=True, exist_ok=True)
+    PLAYER_PHOTOS_DIR.mkdir(parents=True, exist_ok=True)
     ext = Path(filename).suffix.lower() or ".png"
     safe_name = Path(filename).stem.replace(" ", "-")
-    out = photos_dir / f"{safe_name}-{player_id[:6]}{ext}"
+    out = PLAYER_PHOTOS_DIR / f"{safe_name}-{player_id[:6]}{ext}"
     out.write_bytes(content)
     storage.set_photo_path(player_id, str(out))
     return out


### PR DESCRIPTION
## Summary
- centralize common file paths in `app_paths.py`
- use shared path constants in `player_editor.py`
- route player photo storage via `PLAYER_PHOTOS_DIR`

## Testing
- `python -m py_compile app/app_paths.py app/player_editor.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bc3df3218c8320ae4f67e0dd85a209