### PR TITLE
feat: add optional Supabase support

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -9,3 +9,10 @@ PLAYER AGE-MINUTES TOOL
 Make sure Python and Streamlit are installed.
 If needed, install Streamlit with:
     pip install streamlit
+
+### Supabase Sync
+
+Set `SUPABASE_URL` and `SUPABASE_KEY` environment variables to enable
+optional Supabase storage. Functions in `app/sync_utils.py` and
+`app/teams_store.py` will then read and write data to your Supabase tables.
+

--- a/app/supabase_client.py
+++ b/app/supabase_client.py
@@ -1,0 +1,20 @@
+# supabase_client.py
+from __future__ import annotations
+import os
+from functools import lru_cache
+
+try:  # optional dependency
+    from supabase import create_client, Client
+except Exception:  # pragma: no cover - missing supabase
+    create_client = None  # type: ignore
+    Client = None  # type: ignore
+
+@lru_cache
+def get_client() -> "Client | None":
+    """Return a Supabase client if credentials are available, else None."""
+    url = os.environ.get("SUPABASE_URL")
+    key = os.environ.get("SUPABASE_KEY")
+    if not url or not key or create_client is None:
+        return None
+    return create_client(url, key)
+


### PR DESCRIPTION
## Summary
- add Supabase client helper
- support syncing teams and players with Supabase
- document required Supabase env vars

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68bc3d7252908320bb46ab46939207b1