### PR TITLE
refactor: unify json io

### DIFF
--- a/app/add_player_form.py
+++ b/app/add_player_form.py
@@ -13,6 +13,7 @@ from app_paths import file_path, DATA_DIR
 from data_utils import (  # NEW
     load_master, save_master
 )
+from storage import load_json, save_json
 
 PLAYERS_FP = file_path("players.json")
 
@@ -20,15 +21,10 @@ PLAYERS_FP = file_path("players.json")
 # Helpers
 # ---------------------------
 def _load_players() -> list:
-    try:
-        if PLAYERS_FP.exists():
-            return json.loads(PLAYERS_FP.read_text(encoding="utf-8"))
-    except Exception:
-        pass
-    return []
+    return load_json(PLAYERS_FP, [])
 
 def _save_players(data: list) -> None:
-    PLAYERS_FP.write_text(json.dumps(data, ensure_ascii=False, indent=2), encoding="utf-8")
+    save_json(PLAYERS_FP, data)
 
 def _norm_name(s: str) -> str:
     s = (s or "").strip()

--- a/app/calendar_ui.py
+++ b/app/calendar_ui.py
@@ -13,6 +13,7 @@ import streamlit as st
 from zoneinfo import ZoneInfo
 
 from app_paths import file_path, DATA_DIR
+from storage import load_json, save_json
 
 MATCHES_FP = file_path("matches.json")
 
@@ -37,18 +38,10 @@ LOCAL_TZ = "Europe/Helsinki"
 # -------------- IO --------------
 @st.cache_data(show_spinner=False)
 def _load_json(_: int = 0):
-    try:
-        if MATCHES_FP.exists():
-            return json.loads(MATCHES_FP.read_text(encoding="utf-8"))
-    except Exception:
-        pass
-    return []
+    return load_json(MATCHES_FP, [])
 
 def _save_json(data: Any) -> None:
-    try:
-        MATCHES_FP.write_text(json.dumps(data, ensure_ascii=False, indent=2), encoding="utf-8")
-    except Exception:
-        pass
+    save_json(MATCHES_FP, data)
 
 def _bust():
     st.cache_data.clear()

--- a/app/data_manager.py
+++ b/app/data_manager.py
@@ -17,18 +17,10 @@ PLAYERS_FP = file_path("players.json")
 
 # ---------- JSON apurit ----------
 def _load_players():
-    try:
-        if PLAYERS_FP.exists():
-            return json.loads(PLAYERS_FP.read_text(encoding="utf-8"))
-    except Exception as e:
-        st.error(f"Failed to read players.json: {e}")
-    return []
+    return load_json(PLAYERS_FP, [])
 
 def _save_players(players):
-    try:
-        PLAYERS_FP.write_text(json.dumps(players, ensure_ascii=False, indent=2), encoding="utf-8")
-    except Exception as e:
-        st.error(f"Failed to write players.json: {e}")
+    save_json(PLAYERS_FP, players)
 
 def _norm_team(p: dict) -> str:
     return (

--- a/app/data_utils_players_json.py
+++ b/app/data_utils_players_json.py
@@ -2,25 +2,17 @@
 import json
 from pathlib import Path
 from app_paths import file_path
+from storage import load_json, save_json
 
 PLAYERS_FP = file_path("players.json")
 
-def safe_load_json(path: Path):
-    try:
-        if Path(path).exists():
-            txt = Path(path).read_text(encoding="utf-8").strip()
-            return json.loads(txt) if txt else []
-    except Exception:
-        pass
-    return []  # LISTA, ei dict
-
 def load_all_players():
-    return safe_load_json(PLAYERS_FP)
+    return load_json(PLAYERS_FP, [])
 
 def get_players_by_team(team_name: str):
-    data = safe_load_json(PLAYERS_FP)  # lista
+    data = load_json(PLAYERS_FP, [])  # lista
     norm = lambda s: (s or "").lower().replace(" ", "")
     return [p for p in data if norm(p.get("team_name") or p.get("Team") or p.get("team")) == norm(team_name)]
 
 def save_players(players_list: list):
-    PLAYERS_FP.write_text(json.dumps(players_list, ensure_ascii=False, indent=2), encoding="utf-8")
+    save_json(PLAYERS_FP, players_list)

--- a/app/home.py
+++ b/app/home.py
@@ -11,20 +11,20 @@ import streamlit as st
 from app_paths import file_path  # meidän polkuapuri (kirjoittaa %APPDATA%/ScoutLens tms.)
 
 # ---------------- Pienet, paikalliset JSON-apurit (ei storage-riippuvuutta) ----------------
-def load_json_fp(fp: Path, default):
+def load_json_fp(fp: Path, default: object | None = None):
     try:
         if fp.exists():
             return json.loads(fp.read_text(encoding="utf-8"))
     except Exception:
         pass
-    return default
+    return [] if default is None else default
 
 def save_json_fp(fp: Path, data):
     fp.parent.mkdir(parents=True, exist_ok=True)
     fp.write_text(json.dumps(data, ensure_ascii=False, indent=2), encoding="utf-8")
 
 # Nämä wrapperit mahdollistavat myöhemmin helpon vaihdon KV/Supabaseen (vaihda vain toteutusta)
-def load_json(name_or_fp: str | Path, default):
+def load_json(name_or_fp: str | Path, default: object | None = None):
     fp = file_path(name_or_fp) if isinstance(name_or_fp, str) else name_or_fp
     return load_json_fp(fp, default)
 

--- a/app/lineup_planner.py
+++ b/app/lineup_planner.py
@@ -3,6 +3,7 @@ import pandas as pd
 import json
 from pathlib import Path
 from data_utils import BASE_DIR, list_teams, load_master
+from storage import load_json, save_json
 
 # Attempt mplsoccer import
 try:
@@ -44,17 +45,12 @@ def get_color(pos):
 def save_lineup(lineup, key):
     LINEUP_DIR.mkdir(exist_ok=True)
     path = LINEUP_DIR / f"{key}_lineup.json"
-    with open(path, 'w') as f:
-        json.dump(lineup, f)
+    save_json(path, lineup)
 
 # Load lineup from JSON file
 def load_lineup(key):
     path = LINEUP_DIR / f"{key}_lineup.json"
-    try:
-        with open(path, 'r') as f:
-            return json.load(f)
-    except FileNotFoundError:
-        return {}
+    return load_json(path, {})
 
 # Draw 4-3-3 lineup on pitch using mplsoccer
 def draw_lineup(lineup):
@@ -94,11 +90,7 @@ def show_lineup_planner():
     else:
         # Load shortlist data
         sl_file = BASE_DIR / "shortlists.json"
-        try:
-            raw = json.loads(sl_file.read_text())
-            shortlists = raw if isinstance(raw, dict) else {}
-        except:
-            shortlists = {}
+        shortlists = load_json(sl_file, {})
         sl_names = list(shortlists.keys())
         key = st.selectbox("Select Shortlist", sl_names)
         if not key:

--- a/app/notes.py
+++ b/app/notes.py
@@ -8,18 +8,14 @@ from typing import Any, Dict, List, Optional
 import pandas as pd
 import streamlit as st
 from app_paths import file_path, DATA_DIR
+from storage import load_json
 
 NOTES_FP = file_path("notes.json")
 
 # ---------- IO ----------
 @st.cache_data(show_spinner=False)
-def _load_json(fp: Path, default):
-    try:
-        if fp.exists():
-            return json.loads(fp.read_text(encoding="utf-8"))
-    except Exception:
-        pass
-    return default
+def _load_json(fp: Path, default: object | None = None):
+    return load_json(fp, default)
 
 def _save_json_atomic(fp: Path, data: Any) -> None:
     try:

--- a/app/player_editor.py
+++ b/app/player_editor.py
@@ -10,7 +10,7 @@ import pandas as pd
 import streamlit as st
 
 # --- storage (Supabase jos secrets, muuten JSON) ---
-from storage import Storage
+from storage import Storage, load_json, save_json
 storage = Storage()
 
 # --- projektin apurit ---
@@ -38,16 +38,11 @@ DEFAULT_COLUMNS = [
 
 TM_RX = re.compile(r"^https?://(www\.)?transfermarkt\.[^/\s]+/.*", re.IGNORECASE)
 
-def _load_json(fp: Path, default):
-    try:
-        if fp.exists():
-            return json.loads(fp.read_text(encoding="utf-8"))
-    except Exception:
-        pass
-    return default
+def _load_json(fp: Path, default: object | None = None):
+    return load_json(fp, default)
 
 def _save_json(fp: Path, data):
-    fp.write_text(json.dumps(data, ensure_ascii=False, indent=2), encoding="utf-8")
+    save_json(fp, data)
 
 def _normalize_nationality(val) -> str:
     if val is None:

--- a/app/player_preview.py
+++ b/app/player_preview.py
@@ -6,6 +6,8 @@ import re
 import pandas as pd
 import streamlit as st
 
+from storage import load_json
+
 def _inject_css_once(key: str, css_html: str):
     sskey = f"__css_injected__{key}"
     if not st.session_state.get(sskey):
@@ -23,13 +25,8 @@ MATCHES_FP = file_path("matches.json")
 TEAMS_FP   = file_path("teams.json")  # fallbackia varten
 
 # ---- perus JSON-apurit
-def _load_json(fp: Path, default):
-    try:
-        if fp.exists():
-            return json.loads(fp.read_text(encoding="utf-8"))
-    except Exception:
-        pass
-    return default
+def _load_json(fp: Path, default: object | None = None):
+    return load_json(fp, default)
 
 # ---- tiimit: käytä teams_storea, muuten fallback
 try:

--- a/app/scout_reporter.py
+++ b/app/scout_reporter.py
@@ -22,6 +22,7 @@ from typing import Any, Dict, List
 import pandas as pd
 import streamlit as st
 import plotly.express as px
+from storage import load_json, save_json
 
 
 # ---------------- Mini CSS helper ----------------
@@ -40,20 +41,12 @@ REPORTS_FP    = file_path("scout_reports.json")
 
 
 # ---------------- JSON helpers ----------------
-def _load_json(fp, default):
-    try:
-        if fp.exists():
-            return json.loads(fp.read_text(encoding="utf-8"))
-    except Exception as e:
-        st.warning(f"Could not read {fp.name}: {e}")
-    return default
+def _load_json(fp, default: object | None = None):
+    return load_json(fp, default)
 
 
 def _save_json(fp, data):
-    try:
-        fp.write_text(json.dumps(data, ensure_ascii=False, indent=2), encoding="utf-8")
-    except Exception as e:
-        st.error(f"Could not write {fp.name}: {e}")
+    save_json(fp, data)
 
 
 def _save_json_atomic(fp, data):

--- a/app/shortlists.py
+++ b/app/shortlists.py
@@ -7,28 +7,19 @@ from typing import Any, Dict, List
 import streamlit as st
 
 from app_paths import file_path
+from storage import load_json, save_json
 
 PLAYERS_FP     = file_path("players.json")
 SHORTLISTS_FP  = file_path("shortlists.json")
 
 # ---------- IO ----------
 @st.cache_data(show_spinner=False)
-def _read_json(path: Path):
-    try:
-        return json.loads(path.read_text(encoding="utf-8"))
-    except Exception:
-        return None
-
-def _save_json(path: Path, data: Any):
-    path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(json.dumps(data, ensure_ascii=False, indent=2), encoding="utf-8")
-
 def _load_players() -> List[Dict[str, Any]]:
-    data = _read_json(PLAYERS_FP) or []
+    data = load_json(PLAYERS_FP, [])
     return data if isinstance(data, list) else []
 
 def _load_shortlists() -> Dict[str, List[str]]:
-    root = _read_json(SHORTLISTS_FP) or {}
+    root = load_json(SHORTLISTS_FP, {})
     return root if isinstance(root, dict) else {}
 
 # ---------- helpers ----------
@@ -77,12 +68,12 @@ def show_shortlists():
             nn = new_nm.strip()
             if nn and nn not in shortlists:
                 shortlists[nn] = []
-                _save_json(SHORTLISTS_FP, shortlists)
+                save_json(SHORTLISTS_FP, shortlists)
                 st.success(f"Created '{nn}'")
                 st.cache_data.clear(); st.rerun()
         if sel in shortlists and c2.button("Delete"):
             shortlists.pop(sel, None)
-            _save_json(SHORTLISTS_FP, shortlists)
+            save_json(SHORTLISTS_FP, shortlists)
             st.warning(f"Deleted '{sel}'")
             st.cache_data.clear(); st.rerun()
 
@@ -91,7 +82,7 @@ def show_shortlists():
             rn = st.text_input("Rename", value=sel, key="sl_rename")
             if rn.strip() and rn.strip() != sel and st.button("Apply rename"):
                 shortlists[rn.strip()] = shortlists.pop(sel)
-                _save_json(SHORTLISTS_FP, shortlists)
+                save_json(SHORTLISTS_FP, shortlists)
                 st.success("Renamed")
                 st.cache_data.clear(); st.rerun()
 
@@ -111,12 +102,12 @@ def show_shortlists():
                         shortlists[sel].append(n)
                         added += 1
                 if added:
-                    _save_json(SHORTLISTS_FP, shortlists)
+                    save_json(SHORTLISTS_FP, shortlists)
                     st.success(f"Added {added} players")
                     st.cache_data.clear(); st.rerun()
             if cclear.button("Clear list"):
                 shortlists[sel] = []
-                _save_json(SHORTLISTS_FP, shortlists)
+                save_json(SHORTLISTS_FP, shortlists)
                 st.warning("Cleared")
                 st.cache_data.clear(); st.rerun()
 
@@ -132,12 +123,12 @@ def show_shortlists():
                     rc1.write(f"- **{nm}**")
                     if rc2.button("⬆️", key=f"up_{sel}_{i}", help="Move up") and i>0:
                         items[i-1], items[i] = items[i], items[i-1]
-                        _save_json(SHORTLISTS_FP, shortlists); st.rerun()
+                        save_json(SHORTLISTS_FP, shortlists); st.rerun()
                     if rc3.button("⬇️", key=f"dn_{sel}_{i}", help="Move down") and i < len(items)-1:
                         items[i+1], items[i] = items[i], items[i+1]
-                        _save_json(SHORTLISTS_FP, shortlists); st.rerun()
+                        save_json(SHORTLISTS_FP, shortlists); st.rerun()
                     if rc4.button("Remove", key=f"rm_{sel}_{i}"):
-                        items.pop(i); _save_json(SHORTLISTS_FP, shortlists); st.rerun()
+                        items.pop(i); save_json(SHORTLISTS_FP, shortlists); st.rerun()
 
                 # export
                 st.divider()

--- a/app/storage.py
+++ b/app/storage.py
@@ -20,7 +20,16 @@ def file_path(name: str) -> Path:
     p.parent.mkdir(parents=True, exist_ok=True)
     return p
 
-def load_json(name_or_fp: str | Path, default):
+def load_json(name_or_fp: str | Path, default: object | None = None):
+    """Read JSON from *name_or_fp* using UTF-8.
+
+    Returns ``default`` (or ``[]`` when omitted) if the file is missing or
+    cannot be decoded. A new list is created for the implicit default to avoid
+    sharing state between calls.
+    """
+    if default is None:
+        default = []
+
     p = file_path(name_or_fp) if isinstance(name_or_fp, str) else Path(name_or_fp)
     try:
         if p.exists():
@@ -45,7 +54,9 @@ class Storage:
     def file_path(self, name: str) -> Path:
         return self.base_dir / name
 
-    def read_json(self, fp: Path, default):
+    def read_json(self, fp: Path, default: object | None = None):
+        if default is None:
+            default = []
         try:
             if fp.exists():
                 return json.loads(fp.read_text(encoding="utf-8"))

--- a/app/sync_utils.py
+++ b/app/sync_utils.py
@@ -7,19 +7,9 @@ import pandas as pd
 
 from app_paths import file_path
 from data_utils import load_master
+from storage import load_json, save_json
 
 PLAYERS_FP = file_path("players.json")
-
-def _load_json(fp: Path, default):
-    try:
-        if fp.exists():
-            return json.loads(fp.read_text(encoding="utf-8"))
-    except Exception:
-        pass
-    return default
-
-def _save_json(fp: Path, data):
-    fp.write_text(json.dumps(data, ensure_ascii=False, indent=2), encoding="utf-8")
 
 def _norm_nat(v):
     if v is None: return ""
@@ -32,7 +22,7 @@ def bulk_sync_team_to_players_json(team_name: str) -> int:
     if df is None or df.empty:
         return 0
 
-    players = _load_json(PLAYERS_FP, [])
+    players = load_json(PLAYERS_FP, [])
     index_by_key = {(p.get("name","").strip(), p.get("team_name","").strip()): i for i,p in enumerate(players)}
 
     added_or_updated = 0
@@ -59,5 +49,5 @@ def bulk_sync_team_to_players_json(team_name: str) -> int:
             players.append(rec)
         added_or_updated += 1
 
-    _save_json(PLAYERS_FP, players)
+    save_json(PLAYERS_FP, players)
     return added_or_updated

--- a/app/team_view.py
+++ b/app/team_view.py
@@ -17,6 +17,7 @@ import pandas as pd
 import streamlit as st
 
 from app_paths import file_path, DATA_DIR
+from storage import load_json, save_json
 
 # -------------------- CONFIG / STATE KEYS --------------------
 STATE_TEAM_KEY        = "team_view__selected_team"
@@ -49,29 +50,15 @@ def _safe_str(v: Any) -> str:
     return "" if v is None else str(v)
 
 @st.cache_data(show_spinner=False)
-def _load_json(fp: Path, default, cache_buster: int = 0):
+def _load_json(fp: Path, default: object | None = None, cache_buster: int = 0):
     """Cached JSON loader with a manual cache-buster."""
-    try:
-        p = Path(fp)
-        if p.exists():
-            return json.loads(p.read_text(encoding="utf-8"))
-    except Exception:
-        pass
-    return default
+    return load_json(fp, default)
 
 def _save_json(fp: Path, data: Any) -> None:
-    try:
-        Path(fp).write_text(json.dumps(data, ensure_ascii=False, indent=2), encoding="utf-8")
-    except Exception:
-        pass
+    save_json(fp, data)
 
 def _load_shortlist() -> set:
-    try:
-        if SHORTLIST_FP.exists():
-            return set(json.loads(SHORTLIST_FP.read_text(encoding="utf-8")))
-    except Exception:
-        pass
-    return set()
+    return set(load_json(SHORTLIST_FP, []))
 
 def _save_shortlist(s: set) -> None:
     _save_json(SHORTLIST_FP, sorted(list(s)))

--- a/app/teams_store.py
+++ b/app/teams_store.py
@@ -2,20 +2,10 @@
 from pathlib import Path
 import json
 from app_paths import file_path
+from storage import load_json, save_json
 
 TEAMS_FP   = file_path("teams.json")
 PLAYERS_FP = file_path("players.json")
-
-def _load(fp: Path, default):
-    try:
-        if Path(fp).exists():
-            return json.loads(Path(fp).read_text(encoding="utf-8"))
-    except Exception:
-        pass
-    return default
-
-def _save(fp: Path, data):
-    Path(fp).write_text(json.dumps(data, ensure_ascii=False, indent=2), encoding="utf-8")
 
 def _norm_team(p: dict) -> str:
     # ✅ Huom: ei enää lueta current_club/CurrentClub kenttiä
@@ -23,8 +13,8 @@ def _norm_team(p: dict) -> str:
 
 def list_teams_all() -> list[str]:
     """teams.json ∪ players.json(team_name/Team/team)"""
-    teams = set(_load(TEAMS_FP, []))
-    for p in _load(PLAYERS_FP, []):
+    teams = set(load_json(TEAMS_FP, []))
+    for p in load_json(PLAYERS_FP, []):
         t = _norm_team(p)
         if t:
             teams.add(t)
@@ -34,12 +24,12 @@ def add_team(name: str) -> bool:
     name = (name or "").strip()
     if not name:
         return False
-    teams = set(_load(TEAMS_FP, []))
+    teams = set(load_json(TEAMS_FP, []))
     if name not in teams:
         teams.add(name)
-        _save(TEAMS_FP, sorted(teams))
+        save_json(TEAMS_FP, sorted(teams))
     return True
 
 def remove_team(name: str) -> None:
-    teams = [t for t in _load(TEAMS_FP, []) if t != name]
-    _save(TEAMS_FP, teams)
+    teams = [t for t in load_json(TEAMS_FP, []) if t != name]
+    save_json(TEAMS_FP, teams)

--- a/app/visual_analytics.py
+++ b/app/visual_analytics.py
@@ -7,30 +7,22 @@ from pathlib import Path
 
 from app_paths import file_path, DATA_DIR
 from data_utils import list_teams, load_master
+from storage import load_json
 
 # ---------- JSON-polut ----------
 PLAYERS_FP    = file_path("players.json")
 SHORTLISTS_FP = file_path("shortlists.json")
 
-# ---------- apurit ----------
-def _load_json(fp: Path, default):
-    try:
-        if Path(fp).exists():
-            return json.loads(Path(fp).read_text(encoding="utf-8"))
-    except Exception:
-        pass
-    return default
-
 def list_shortlists_json():
-    return sorted(_load_json(SHORTLISTS_FP, {}).keys())
+    return sorted(load_json(SHORTLISTS_FP, {}).keys())
 
 def get_shortlist_members_json(name: str):
-    sl = _load_json(SHORTLISTS_FP, {})
+    sl = load_json(SHORTLISTS_FP, {})
     return [str(x) for x in sl.get(name, [])]
 
 def get_all_players_map_id_to_name():
     """Palauttaa dictin: {player_id(str): name(str)} players.jsonista."""
-    players = _load_json(PLAYERS_FP, [])
+    players = load_json(PLAYERS_FP, [])
     out = {}
     for p in players:
         pid = str(p.get("id") or p.get("PlayerID") or "")


### PR DESCRIPTION
## Summary
- centralize JSON load helper with UTF-8 and safe default handling
- update app modules to use shared load/save helpers

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bc3edd35248320a401e49baeaacfab