### PR TITLE
feat: add futuristic dark theme

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -9,6 +9,7 @@
 # =============================================================================
 
 from __future__ import annotations
+from pathlib import Path
 import streamlit as st
 
 # --- Pages
@@ -26,107 +27,17 @@ APP_VERSION = "0.9.1"
 # Page config must be first Streamlit call
 st.set_page_config(page_title=APP_TITLE, layout="wide")
 
-# --------- Sidebar CSS (inject every run) ----------
-SIDEBAR_CSS = r"""
-:root{
-  --sb-bg-1:#0d1117;
-  --sb-bg-2:#111827;
-  --sb-fg:#e5e7eb;
-  --sb-fg-dim:#cbd5e1;
-  --sb-ac-1:#6366f1;
-  --sb-ac-2:#0ea5e9;
-  --sb-border:rgba(255,255,255,.08);
-  --sb-border-strong:rgba(255,255,255,.18);
-  --sb-item:rgba(255,255,255,.04);
-  --sb-item-hover:rgba(255,255,255,.08);
-  --sb-shadow:0 6px 24px rgba(0,0,0,.35);
-}
+# --------- Global CSS injection ----------
+def inject_css():
+    base = Path("app/styles")
+    css = "\n".join(
+        (base / f).read_text(encoding="utf-8")
+        for f in ["tokens.css", "layout.css", "components.css", "sidebar.css", "animations.css"]
+        if (base / f).exists()
+    )
+    st.markdown(f"<style>{css}</style>", unsafe_allow_html=True)
 
-section[data-testid="stSidebar"]{
-  background: linear-gradient(180deg,var(--sb-bg-1),var(--sb-bg-2));
-  color:var(--sb-fg);
-  box-shadow: inset -1px 0 0 rgba(255,255,255,.03);
-}
-section[data-testid="stSidebar"] .block-container{
-  padding-top: 12px; padding-bottom: 18px;
-}
-
-/* Brand */
-.scout-brand{
-  font-weight: 900; letter-spacing:.3px; margin: 2px 0 2px 0;
-  font-size: 1.15rem;
-  background: linear-gradient(90deg, var(--sb-fg), #ffffff 30%, var(--sb-fg));
-  -webkit-background-clip: text; background-clip: text; color: transparent;
-}
-.scout-sub{ opacity:.75; margin-top:-4px; font-size:.85rem; color:var(--sb-fg-dim); }
-
-/* Section header */
-.nav-sep{
-  margin: 10px 0 6px 0; font-size:.78rem; text-transform:uppercase; letter-spacing:.12rem;
-  color:var(--sb-fg-dim); opacity:.9;
-}
-
-/* Radio pills (sidebar only) */
-section[data-testid="stSidebar"] [role="radiogroup"]{
-  gap:8px;
-}
-section[data-testid="stSidebar"] [role="radiogroup"] > label{
-  border:1px solid var(--sb-border);
-  background:var(--sb-item);
-  border-radius:12px;
-  padding:10px 12px;
-  transition:transform .08s ease, background .15s ease, border-color .15s ease, box-shadow .15s ease;
-  cursor:pointer;
-  display:flex; align-items:center; gap:.55rem;
-  position: relative; isolation:isolate;
-  min-height: 42px;
-}
-
-/* Hide native bullet */
-section[data-testid="stSidebar"] [role="radiogroup"] input[type="radio"]{ display:none; }
-
-/* Hover */
-section[data-testid="stSidebar"] [role="radiogroup"] > label:hover{
-  background:var(--sb-item-hover);
-  border-color:var(--sb-border-strong);
-  transform:translateX(2px);
-  box-shadow: var(--sb-shadow);
-}
-
-/* Selected (preferred) */
-section[data-testid="stSidebar"] [role="radiogroup"] > label:has(input:checked){
-  background:linear-gradient(135deg, color-mix(in srgb, var(--sb-ac-1) 30%, transparent),
-                                      color-mix(in srgb, var(--sb-ac-2) 30%, transparent));
-  border-color: color-mix(in srgb, var(--sb-ac-1) 65%, var(--sb-border-strong));
-  box-shadow: 0 8px 26px color-mix(in srgb, var(--sb-ac-1) 35%, transparent);
-}
-/* Selected (fallback for browsers without :has) */
-section[data-testid="stSidebar"] [role="radiogroup"] > label:focus-within{
-  background:linear-gradient(135deg, color-mix(in srgb, var(--sb-ac-1) 22%, transparent),
-                                      color-mix(in srgb, var(--sb-ac-2) 22%, transparent));
-  border-color: color-mix(in srgb, var(--sb-ac-1) 55%, var(--sb-border-strong));
-}
-
-/* Left accent bar when selected */
-section[data-testid="stSidebar"] [role="radiogroup"] > label:has(input:checked)::before{
-  content:""; position:absolute; left:0; top:0; bottom:0; width:4px;
-  border-radius:12px 0 0 12px;
-  background: linear-gradient(180deg, var(--sb-ac-1), var(--sb-ac-2));
-}
-
-/* Label text */
-section[data-testid="stSidebar"] [role="radiogroup"] > label *{ color:var(--sb-fg); }
-
-/* Footer card */
-.sb-footer{
-  margin-top:14px; padding:12px 12px;
-  border:1px solid var(--sb-border);
-  border-radius:12px; background:var(--sb-item);
-  color:var(--sb-fg-dim); font-size:.82rem;
-}
-.sb-footer strong{ color:var(--sb-fg); }
-"""
-st.markdown(f"<style>{SIDEBAR_CSS}</style>", unsafe_allow_html=True)
+inject_css()
 
 # --------- Navigation setup ----------
 # Näkyvät sivut sivupalkissa:

--- a/app/home.py
+++ b/app/home.py
@@ -97,9 +97,6 @@ def _match_dt(m: Dict[str, Any]) -> Optional[datetime]:
         return datetime.combine(d, dtime(0, 0))
     return None
 
-def _go_to(page: str):
-    st.session_state["nav_page"] = page
-    st.rerun()
 
 # ---------------- Data helpers ----------------
 def _load_players() -> List[Dict[str, Any]]:
@@ -117,28 +114,12 @@ def _append_note(text: str):
     notes.append({"ts": datetime.now().isoformat(timespec="seconds"), "text": text.strip()})
     save_json(NOTES_FN, notes)
 
-# ---------------- CSS ----------------
-HOME_CSS = r"""
-:root{
-  --fg:#e5e7eb; --fg-dim:#cbd5e1;
-  --card:#0f172a; --card-2:#0b1220; --muted:#94a3b8;
-  --ac1:#6366f1; --ac2:#0ea5e9; --ok:#10b981; --warn:#f59e0b; --bad:#ef4444;
-}
-.block {background:var(--card); border:1px solid #1f2937; border-radius:14px; padding:14px;}
-.kpi   {background:var(--card-2); border:1px solid #1f2937; border-radius:14px; padding:14px;}
-h1,h2,h3, .small {color:var(--fg);}
-.small {font-size:0.9rem; color:var(--fg-dim);}
-.row {margin-top:8px; margin-bottom:6px;}
-.badge {display:inline-block; padding:2px 8px; border-radius:999px; background:#111827; color:var(--muted); border:1px solid #1f2937;}
-"""
-
 def _metric(label: str, value: Any, help_text: Optional[str] = None):
     st.markdown(
-        f'<div class="kpi"><div class="small">{label}</div>'
-        f'<div style="font-size:1.8rem;font-weight:700">{value}</div>'
-        f'{f"<div class=small>{help_text}</div>" if help_text else ""}'
-        f'</div>',
-        unsafe_allow_html=True
+        f"<div class='sl-kpi'><div class='label'>{label}</div>"
+        f"<div class='value'>{value}</div>"
+        f"{f'<div class=\"label\">{help_text}</div>' if help_text else ''}</div>",
+        unsafe_allow_html=True,
     )
 
 # ---------------- Admin / Utilities ----------------
@@ -166,7 +147,18 @@ def _export_zip() -> bytes:
 
 # ---------------- Main ----------------
 def show_home():
-    st.markdown(f"<style>{HOME_CSS}</style>", unsafe_allow_html=True)
+    if st.sidebar.checkbox("Style self-check", False):
+        st.markdown(
+            "<div class='sl-kpi'><div class='label'>Demo KPI</div><div class='value'>42</div></div>",
+            unsafe_allow_html=True,
+        )
+        st.markdown("<a class='sl-btn'>Primary</a>", unsafe_allow_html=True)
+        st.markdown("<span class='sl-chip'>Chip</span>", unsafe_allow_html=True)
+        st.markdown(
+            "<div class='sl-table'><table><thead><tr><th>A</th><th>B</th></tr></thead><tbody><tr><td>1</td><td><span class='sl-badge-link'>7.5</span></td></tr></tbody></table></div>",
+            unsafe_allow_html=True,
+        )
+        return
 
     # ---- Header
     st.markdown("### 🏠 Home")
@@ -218,17 +210,18 @@ def show_home():
 
     # ---- Quick Actions (ei nested columns -ongelmia)
     st.markdown("#### ⚡ Pika-toiminnot")
-    qa1, qa2, qa3, qa4, qa5 = st.columns(5)
-    if qa1.button("👥 Team View", use_container_width=True):
-        _go_to("Team View")
-    if qa2.button("🧑‍💻 Player Editor", use_container_width=True):
-        _go_to("Player Editor")
-    if qa3.button("📝 Match Reporter", use_container_width=True):
-        _go_to("Match Reporter")
-    if qa4.button("🗓️ Kalenteri", use_container_width=True):
-        _go_to("Calendar")
-    if qa5.button("🗒️ Muistiinpanot", use_container_width=True):
-        _go_to("Notes")
+    st.markdown(
+        """
+        <div class='sl-quick-actions'>
+            <a href='?p=Team%20View' class='sl-btn'>👥 Team View</a>
+            <a href='?p=Player%20Editor' class='sl-btn'>🧑‍💻 Player Editor</a>
+            <a href='?p=Match%20Reporter' class='sl-btn'>📝 Match Reporter</a>
+            <a href='?p=Calendar' class='sl-btn'>🗓️ Kalenteri</a>
+            <a href='?p=Notes' class='sl-btn'>🗒️ Muistiinpanot</a>
+        </div>
+        """,
+        unsafe_allow_html=True,
+    )
 
     st.divider()
 
@@ -257,7 +250,7 @@ def show_home():
             with c1:
                 st.markdown(
                     f'**{row["_dt"].strftime("%a %d.%m.%Y")}**\n\n'
-                    f'<span class="badge">{row.get("time","") or row["_dt"].strftime("%H:%M")}</span>',
+                    f'<span class="sl-chip">{row.get("time","") or row["_dt"].strftime("%H:%M")}</span>',
                     unsafe_allow_html=True
                 )
             with c2:

--- a/app/player_editor.py
+++ b/app/player_editor.py
@@ -544,6 +544,7 @@ def _render_team_editor_flow(selected_team: str, preselected_name: Optional[str]
     # ✏️ Basic Info
     with tabs[0]:
         st.markdown(f"### Editing Player: {selected_name}")
+        st.markdown("<div class='sl-card'>", unsafe_allow_html=True)
 
         c1, c2, c3 = st.columns(3)
         with c1:
@@ -620,6 +621,7 @@ def _render_team_editor_flow(selected_team: str, preselected_name: Optional[str]
                 pid_out = upsert_player_storage(player_data)
                 st.success(f"✅ Saved (id={pid_out})")
 
+        st.markdown("</div>", unsafe_allow_html=True)
     # 🔗 Links
     with tabs[1]:
         st.subheader("🔗 Links")
@@ -631,10 +633,10 @@ def _render_team_editor_flow(selected_team: str, preselected_name: Optional[str]
             tm_url = ""
         st.write("Transfermarkt:", tm_url or "—")
         if tm_url:
-            try:
-                st.link_button("Open Transfermarkt", tm_url, help="Avaa pelaajan Transfermarkt-sivu")
-            except Exception:
-                st.markdown(f"[Open Transfermarkt]({tm_url})")
+            st.markdown(
+                f"<a href='{tm_url}' class='sl-badge-link' target='_blank'>Open Transfermarkt</a>",
+                unsafe_allow_html=True,
+            )
 
     # 🖼️ Photo & Tags
     with tabs[2]:

--- a/app/styles/animations.css
+++ b/app/styles/animations.css
@@ -1,0 +1,15 @@
+/* Micro lift */
+.lift:hover { transform: translateY(-1px); box-shadow: var(--shadow-hover); }
+
+/* Fade in */
+.fade-in { animation: fadeIn .3s ease both; }
+@keyframes fadeIn { from{opacity:0} to{opacity:1} }
+
+/* Skeleton */
+.skeleton { position:relative; overflow:hidden; background:var(--bg-card); }
+.skeleton::after {
+  content:""; position:absolute; inset:0;
+  background:linear-gradient(90deg,transparent,rgba(255,255,255,0.05),transparent);
+  animation: shimmer 1.2s infinite;
+}
+@keyframes shimmer { from{transform:translateX(-100%);} to{transform:translateX(100%);} }

--- a/app/styles/components.css
+++ b/app/styles/components.css
@@ -1,0 +1,85 @@
+/* Cards & KPI */
+.sl-kpi {
+  text-align:left;
+}
+.sl-kpi .label { font-size: var(--fs-14); color: var(--fg-muted); }
+.sl-kpi .value { font-size: var(--fs-28); font-weight:700; }
+
+/* Buttons */
+.stButton>button, .sl-btn {
+  background: var(--accent-1);
+  color: var(--fg-strong);
+  border: none;
+  border-radius: var(--radius-md);
+  padding: var(--space-2) var(--space-3);
+  font-size: var(--fs-14);
+  transition: background .2s ease, box-shadow .2s ease, transform .2s ease;
+}
+.stButton>button:hover, .sl-btn:hover {
+  background: linear-gradient(90deg,var(--accent-1),var(--accent-2));
+  transform: translateY(-1px);
+  box-shadow: var(--shadow-hover);
+}
+.stButton>button:focus, .sl-btn:focus {
+  outline: 2px solid var(--accent-cyan);
+  outline-offset:2px;
+}
+.stButton>button:disabled {
+  opacity:0.5;
+  cursor:not-allowed;
+}
+
+/* Chips */
+.sl-chip {
+  display:inline-block;
+  padding:2px 10px;
+  border-radius:9999px;
+  background:color-mix(in srgb, var(--accent-1) 20%, transparent);
+  border:1px solid var(--accent-1);
+  font-size:var(--fs-12);
+  margin-right:var(--space-2);
+}
+
+/* Table wrapper */
+.sl-table .stDataFrame, .sl-table .stTable {
+  border:1px solid var(--divider);
+  border-radius:var(--radius-md);
+  overflow:hidden;
+}
+.sl-table thead tr { position:sticky; top:0; background:var(--bg-card); }
+.sl-table tbody tr:nth-child(even){ background:rgba(255,255,255,0.02); }
+.sl-table tbody tr:hover{ background:color-mix(in srgb, var(--accent-1) 10%, transparent); }
+
+/* Badge link */
+.sl-badge-link {
+  display:inline-block;
+  padding:2px 12px;
+  border-radius:9999px;
+  background:var(--bg-card);
+  border:1px solid var(--accent-1);
+  color:var(--accent-1);
+  text-decoration:none;
+  font-size:var(--fs-12);
+  transition:background .2s ease;
+}
+.sl-badge-link:hover {
+  background:color-mix(in srgb, var(--accent-1) 20%, transparent);
+}
+
+/* Inputs */
+.stTextInput>div>div>input,
+.stSelectbox>div>div>select,
+.stNumberInput>div>div>input,
+.stDateInput>div>div>input {
+  background:var(--bg-card);
+  border-radius:var(--radius-sm);
+  border:1px solid var(--divider);
+  color:var(--fg-strong);
+}
+.stTextInput>div>div>input:focus,
+.stSelectbox>div>div>select:focus,
+.stNumberInput>div>div>input:focus,
+.stDateInput>div>div>input:focus {
+  border-color:var(--accent-1);
+  box-shadow:0 0 0 1px var(--accent-1);
+}

--- a/app/styles/layout.css
+++ b/app/styles/layout.css
@@ -1,0 +1,27 @@
+html, body, .stApp {
+  background: var(--bg-page);
+  color: var(--fg-strong);
+  font-family: var(--font-sans);
+  line-height: var(--lh-relaxed);
+}
+
+.stApp [data-testid="stHeader"]{
+  background: transparent;
+}
+
+/* Containers */
+.sl-card, .sl-kpi {
+  background: var(--bg-card);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-card);
+  padding: var(--space-4);
+}
+
+/* Scrollbar */
+::-webkit-scrollbar { width: 8px; height:8px; }
+::-webkit-scrollbar-thumb { background: var(--accent-1); border-radius: 4px; }
+::-webkit-scrollbar-track { background: transparent; }
+
+@media (max-width:1024px){
+  .stSidebar { width:56px; }
+}

--- a/app/styles/sidebar.css
+++ b/app/styles/sidebar.css
@@ -1,0 +1,28 @@
+/* Sidebar navigation */
+section[data-testid="stSidebar"] {
+  background: linear-gradient(180deg,#0b0f1a,#0f172a);
+  color: var(--fg-strong);
+  box-shadow: inset -1px 0 0 rgba(255,255,255,0.05);
+}
+section[data-testid="stSidebar"] .block-container { padding:var(--space-5) var(--space-4); }
+
+section[data-testid="stSidebar"] [role="radiogroup"] > label {
+  border:1px solid var(--divider);
+  border-radius:var(--radius-md);
+  padding:var(--space-3);
+  background:transparent;
+  transition:background .2s ease, transform .2s ease;
+  position:relative;
+  display:flex; align-items:center; gap:var(--space-2);
+}
+section[data-testid="stSidebar"] [role="radiogroup"] > label:hover {
+  background:color-mix(in srgb,var(--accent-1) 8%, transparent);
+  transform:translateX(2px);
+}
+section[data-testid="stSidebar"] [role="radiogroup"] > label:has(input:checked) {
+  background:color-mix(in srgb,var(--accent-1) 15%, transparent);
+}
+section[data-testid="stSidebar"] [role="radiogroup"] > label:has(input:checked)::before {
+  content:""; position:absolute; left:0; top:0; bottom:0; width:3px;
+  background:linear-gradient(var(--accent-1),var(--accent-2));
+}

--- a/app/styles/tokens.css
+++ b/app/styles/tokens.css
@@ -1,0 +1,41 @@
+:root {
+  /* Colors */
+  --bg-page: #0b0f1a;
+  --bg-card: #0f172a;
+  --accent-1: #6366f1;
+  --accent-2: #7c3aed;
+  --fg-strong: #e5e7eb;
+  --fg-muted: #9aa3b2;
+  --accent-cyan: #22d3ee;
+  --warning: #f97316;
+  --error: #ef4444;
+  --divider: rgba(255,255,255,0.08);
+
+  /* Typography */
+  --font-sans: 'Inter', sans-serif;
+  --font-mono: 'JetBrains Mono', monospace;
+  --fs-12: 0.75rem;
+  --fs-14: 0.875rem;
+  --fs-16: 1rem;
+  --fs-20: 1.25rem;
+  --fs-28: 1.75rem;
+  --lh-tight: 1.4;
+  --lh-relaxed: 1.6;
+
+  /* Spacing */
+  --space-1: 4px;
+  --space-2: 8px;
+  --space-3: 12px;
+  --space-4: 16px;
+  --space-5: 24px;
+  --space-6: 32px;
+
+  /* Radius */
+  --radius-lg: 16px;
+  --radius-md: 14px;
+  --radius-sm: 6px;
+
+  /* Shadows */
+  --shadow-card: 0 4px 16px rgba(0,0,0,0.4);
+  --shadow-hover: 0 6px 20px rgba(0,0,0,0.6);
+}

--- a/app/team_view.py
+++ b/app/team_view.py
@@ -409,7 +409,8 @@ def show_team_view():
             chips.append(f"🎂 {lo}-{hi}")
     if club_sel: chips.append("🏟️ " + "/".join(club_sel))
     if chips:
-        st.caption("Active filters: " + "   •   ".join(chips))
+        chips_html = " ".join(f"<span class='sl-chip'>{c}</span>" for c in chips)
+        st.markdown(chips_html, unsafe_allow_html=True)
 
     # --------- Advanced: sort + visible columns + starters + shortlist toggle ----------
     with st.expander("Advanced", expanded=False):
@@ -564,7 +565,9 @@ def show_team_view():
     else:
         # Fast table view
         show_cols = preferred_cols if preferred_cols else list(df_show.columns)
+        st.markdown("<div class='sl-table'>", unsafe_allow_html=True)
         st.dataframe(df_show[show_cols].reset_index(drop=True), use_container_width=True, height=520)
+        st.markdown("</div>", unsafe_allow_html=True)
 
     # --------- Export ----------
     st.markdown("### Export")


### PR DESCRIPTION
## Summary
- inject style pack and dark theme tokens
- restyle Home quick actions, KPI demo and filter chips
- apply card and badge classes to Player Editor and tables

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bc48e90d6883209d2cd14b633917d4