### PR TITLE
Add created_at timestamps and Supabase schema

### DIFF
--- a/app/home.py
+++ b/app/home.py
@@ -119,7 +119,7 @@ def _load_notes() -> List[Dict[str, Any]]:
 
 def _append_note(text: str):
     notes = _load_notes()
-    notes.append({"ts": datetime.now().isoformat(timespec="seconds"), "text": text.strip()})
+    notes.append({"created_at": datetime.now().isoformat(timespec="seconds"), "text": text.strip()})
     save_json(NOTES_FN, notes)
 
 def _metric(label: str, value: Any, help_text: Optional[str] = None):
@@ -334,5 +334,5 @@ def show_home():
         else:
             for n in recent:
                 txt = n.get("text", "")
-                ts  = n.get("ts", "")
+                ts  = n.get("created_at", "")
                 st.markdown(f"- **{ts}** — {txt[:140]}{'…' if len(txt) > 140 else ''}")

--- a/app/notes.py
+++ b/app/notes.py
@@ -87,7 +87,7 @@ def show_notes():
             t = (text or "").strip()
             tags = _clean_tags(tags_str or "")
             if t:
-                item = {"id": uuid.uuid4().hex, "ts": _now_iso(), "text": t, "tags": tags}
+                item = {"id": uuid.uuid4().hex, "created_at": _now_iso(), "text": t, "tags": tags}
                 notes.append(item)
                 _save_json_atomic(NOTES_FP, notes)
                 st.cache_data.clear()
@@ -145,16 +145,16 @@ def show_notes():
             tags = n.get("tags", [])
             ok = any(t in tags for t in tag_sel)
         if ok and from_date:
-            ts = _parse_dt(n.get("ts",""))
+            ts = _parse_dt(n.get("created_at",""))
             ok = (ts is not None) and (ts.date() >= from_date)
         if ok and to_date:
-            ts = _parse_dt(n.get("ts",""))
+            ts = _parse_dt(n.get("created_at",""))
             ok = (ts is not None) and (ts.date() <= to_date)
         if ok:
             filt.append(n)
 
     reverse = (sort_order == "Newest first")
-    filt.sort(key=lambda n: n.get("ts",""), reverse=reverse)
+    filt.sort(key=lambda n: n.get("created_at",""), reverse=reverse)
 
     st.caption(f"{len(filt)} / {len(notes)} notes shown")
 
@@ -174,7 +174,7 @@ def show_notes():
     st.markdown("#### Bulk delete")
     if page_items:
         ids = [n["id"] for n in page_items]
-        picks = st.multiselect("Select notes to delete", options=ids, format_func=lambda nid: next((f"{_fmt_ts(n['ts'])}  •  {(n['text'][:40] + '…' if len(n['text'])>40 else n['text'])}" for n in page_items if n['id']==nid), nid), key="notes__bulk")
+        picks = st.multiselect("Select notes to delete", options=ids, format_func=lambda nid: next((f"{_fmt_ts(n['created_at'])}  •  {(n['text'][:40] + '…' if len(n['text'])>40 else n['text'])}" for n in page_items if n['id']==nid), nid), key="notes__bulk")
         st.warning("Type DELETE to confirm bulk deletion.", icon="⚠️")
         confirm = st.text_input("Confirmation", key="notes__confirm", placeholder="DELETE")
         if st.button(f"🗑️ Delete selected ({len(picks)})", disabled=(len(picks)==0 or confirm!="DELETE"), key="notes__bulk_del"):
@@ -194,7 +194,7 @@ def show_notes():
             with st.container(border=True):
                 top = st.columns([2.4, 1.2, 0.9])
                 with top[0]:
-                    st.caption(_fmt_ts(n.get("ts")))
+                    st.caption(_fmt_ts(n.get("created_at")))
                 with top[1]:
                     tg = n.get("tags", []) or []
                     if tg:

--- a/app/scout_reporter.py
+++ b/app/scout_reporter.py
@@ -123,6 +123,8 @@ def list_scout_reports() -> List[Dict[str, Any]]:
 
 def insert_scout_report(r: Dict[str, Any]) -> None:
     reps = _load_json(REPORTS_FP, [])
+    if "created_at" not in r:
+        r["created_at"] = datetime.now().isoformat()
     reps.append({"id": uuid.uuid4().hex, **r})
     _save_json_atomic(REPORTS_FP, reps)
 
@@ -366,8 +368,7 @@ def show_scout_match_reporter():
             "foot": foot,
             "position": position_final,
             "ratings": json.dumps(ratings, ensure_ascii=False),
-            "general_comment": general.strip(),
-            "created_at": datetime.now().isoformat()
+            "general_comment": general.strip()
         })
         st.success(f"Report saved for {sel_player.get('name','?')}.")
 

--- a/supabase/001_create_tables.sql
+++ b/supabase/001_create_tables.sql
@@ -1,0 +1,70 @@
+-- 001_create_tables.sql
+-- Schema definitions for ScoutLens Supabase tables.
+-- Ensure each table includes all fields required by the UI and a created_at timestamp.
+
+create extension if not exists "uuid-ossp";
+
+create table if not exists players (
+    id uuid primary key default uuid_generate_v4(),
+    name text not null,
+    team_name text not null,
+    date_of_birth date,
+    nationality text,
+    height integer,
+    weight integer,
+    preferred_foot text,
+    club_number integer,
+    primary_position text,
+    secondary_positions text[],
+    notes text,
+    tags text[],
+    photo_path text,
+    created_at timestamptz not null default now()
+);
+
+create table if not exists teams (
+    id uuid primary key default uuid_generate_v4(),
+    name text unique not null,
+    created_at timestamptz not null default now()
+);
+
+create table if not exists matches (
+    id uuid primary key default uuid_generate_v4(),
+    date date,
+    time text,
+    tz text,
+    home text,
+    away text,
+    competition text,
+    location text,
+    city text,
+    targets text[],
+    notes text,
+    created_at timestamptz not null default now()
+);
+
+create table if not exists scout_reports (
+    id uuid primary key default uuid_generate_v4(),
+    match_id uuid references matches(id) on delete cascade,
+    player_id uuid references players(id) on delete cascade,
+    competition text,
+    foot text,
+    position text,
+    ratings jsonb,
+    general_comment text,
+    created_at timestamptz not null default now()
+);
+
+create table if not exists shortlists (
+    id uuid primary key default uuid_generate_v4(),
+    name text not null,
+    items jsonb,
+    created_at timestamptz not null default now()
+);
+
+create table if not exists notes (
+    id uuid primary key default uuid_generate_v4(),
+    text text not null,
+    tags text[],
+    created_at timestamptz not null default now()
+);


### PR DESCRIPTION
## Summary
- define Supabase tables with required fields and created_at timestamps
- rely on automatic created_at when saving scout reports
- use created_at for notes and quick notes

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bc5b5934d48320ae75a322bfa0ffbf