### PR TITLE
feat: sync supabase tables

### DIFF
--- a/app/home.py
+++ b/app/home.py
@@ -187,14 +187,14 @@ def show_home():
         )
 
     # ---- Cloud Sync (Supabase)
-    bucket = st.secrets.get("SUPABASE_BUCKET", "scoutlens")
     st.subheader("Cloud Sync (Supabase)")
     col1, col2 = st.columns(2)
 
     with col1:
         if st.button("Backup → Supabase"):
             for name in FILES:
-                ok, msg = push_json(bucket, name, file_path(name))
+                table = Path(name).stem
+                ok, msg = push_json(table, file_path(name))
                 if ok:
                     st.write("✅ " + msg)
                 else:
@@ -203,7 +203,8 @@ def show_home():
     with col2:
         if st.button("Restore ← Supabase"):
             for name in FILES:
-                ok, msg = pull_json(bucket, name, file_path(name))
+                table = Path(name).stem
+                ok, msg = pull_json(table, file_path(name))
                 if ok:
                     st.write("✅ " + msg)
                 else:

--- a/app/sync_utils.py
+++ b/app/sync_utils.py
@@ -1,35 +1,44 @@
 from __future__ import annotations
+import json
+import os
 from pathlib import Path
+
 import streamlit as st
 from supabase import create_client
 
 
 def _client():
-    url = st.secrets["SUPABASE_URL"]
-    key = st.secrets["SUPABASE_ANON_KEY"]
+    """Create a Supabase client using service role credentials."""
+    url = os.environ.get("SUPABASE_URL") or st.secrets.get("SUPABASE_URL")
+    key = os.environ.get("SUPABASE_SERVICE_ROLE") or st.secrets.get(
+        "SUPABASE_SERVICE_ROLE"
+    )
+    if not url or not key:
+        raise RuntimeError("Supabase credentials not configured")
     return create_client(url, key)
 
 
-def push_json(bucket: str, key: str, local_fp: Path) -> tuple[bool, str]:
+def push_json(table: str, local_fp: Path) -> tuple[bool, str]:
+    """Read a local JSON file and upsert rows into a Supabase table."""
     try:
         sb = _client()
-        data_bytes = local_fp.read_bytes()
-        sb.storage.from_(bucket).upload(
-            path=key,
-            file=data_bytes,
-            file_options={"content-type": "application/json", "upsert": True},
-        )
-        return True, f"Uploaded {key}"
-    except Exception as e:
+        payload = json.loads(local_fp.read_text(encoding="utf-8"))
+        if isinstance(payload, dict):
+            payload = [payload]
+        sb.table(table).upsert(payload).execute()
+        return True, f"Upserted {len(payload)} rows into {table}"
+    except Exception as e:  # pragma: no cover - supabase network issues
         return False, str(e)
 
 
-def pull_json(bucket: str, key: str, local_fp: Path) -> tuple[bool, str]:
+def pull_json(table: str, local_fp: Path) -> tuple[bool, str]:
+    """Fetch rows from a Supabase table and write them to a local JSON file."""
     try:
         sb = _client()
-        res = sb.storage.from_(bucket).download(key)
+        res = sb.table(table).select("*").execute()
+        data = res.data if hasattr(res, "data") else res
         local_fp.parent.mkdir(parents=True, exist_ok=True)
-        local_fp.write_bytes(res)
-        return True, f"Downloaded {key}"
-    except Exception as e:
+        local_fp.write_text(json.dumps(data, ensure_ascii=False, indent=2), encoding="utf-8")
+        return True, f"Downloaded {len(data)} rows from {table}"
+    except Exception as e:  # pragma: no cover - supabase network issues
         return False, str(e)


### PR DESCRIPTION
## Summary
- use service role credentials for Supabase client
- push/pull JSON data directly to Supabase tables
- update home sync to use table-based backup and restore

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bc5b5cdee88320a3958bd9916a7d7f