### PR TITLE
Use Supabase mocks in tests and update developer docs

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -16,3 +16,33 @@ Set `SUPABASE_URL` and `SUPABASE_KEY` environment variables to enable
 optional Supabase storage. Functions in `app/sync_utils.py` and
 `app/teams_store.py` will then read and write data to your Supabase tables.
 
+#### Developer Setup
+
+1. Create a project at [Supabase](https://supabase.com) and copy the API URL
+   and service role or anon key from the dashboard.
+2. Create a storage bucket (for example, `data`) for JSON files.
+3. Export the required environment variables before running ScoutLens or the
+   sync helpers:
+
+   ```bash
+   export SUPABASE_URL="https://<project>.supabase.co"
+   export SUPABASE_KEY="<service-role-or-anon-key>"
+   # Optional: set to 1 to force cloud mode
+   export SCOUTLENS_CLOUD=1
+   ```
+
+The application reads and writes JSON data to Supabase storage through
+`app/sync_utils.py`. Example usage of the utilities:
+
+```bash
+python - <<'PY'
+from pathlib import Path
+from sync_utils import push_json, pull_json
+
+push_json('data', 'players.json', Path('local_players.json'))
+pull_json('data', 'players.json', Path('downloaded_players.json'))
+PY
+```
+
+Replace `'data'` with your bucket name and adjust file paths as needed.
+

--- a/tests/test_data_utils.py
+++ b/tests/test_data_utils.py
@@ -1,7 +1,6 @@
 import sys
 from pathlib import Path
 import importlib
-import json
 import pandas as pd
 
 # Ensure application modules can be imported as top-level modules
@@ -9,11 +8,35 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "app"))
 
 
 def setup_data_utils(tmp_path, monkeypatch):
+    """Return ``data_utils`` configured to use an in-memory Supabase mock."""
     monkeypatch.setenv("SCOUTLENS_APPDATA", str(tmp_path))
+
     import app_paths
     importlib.reload(app_paths)
+
+    # Mock cloud storage using an in-memory dictionary
+    store: dict[str, object] = {}
+
     import storage
-    monkeypatch.setattr(storage, "IS_CLOUD", False)
+    importlib.reload(storage)
+    monkeypatch.setattr(storage, "IS_CLOUD", True, raising=False)
+
+    def fake_load_json(name_or_fp, default):
+        key = Path(name_or_fp).name if name_or_fp else ""
+        return store.get(key, default)
+
+    def fake_save_json(name_or_fp, data):
+        key = Path(name_or_fp).name if name_or_fp else ""
+        store[key] = data
+
+    monkeypatch.setattr(storage, "load_json", fake_load_json, raising=False)
+    monkeypatch.setattr(storage, "save_json", fake_save_json, raising=False)
+
+    # Prevent real Supabase connections
+    import supabase_client
+    importlib.reload(supabase_client)
+    monkeypatch.setattr(supabase_client, "get_client", lambda: object())
+
     import data_utils
     importlib.reload(data_utils)
     return data_utils
@@ -22,25 +45,28 @@ def setup_data_utils(tmp_path, monkeypatch):
 def test_list_teams(tmp_path, monkeypatch):
     du = setup_data_utils(tmp_path, monkeypatch)
     assert du.list_teams() == []
-    du.PLAYERS_FP.write_text(
-        json.dumps([{ "team_name": "Team A" }, { "team_name": "Team B" }]),
-        encoding="utf-8",
+
+    import storage
+
+    storage.save_json(
+        "players.json",
+        [
+            {"team_name": "Team A"},
+            {"team_name": "Team B"},
+            {"team_name": "TEAM_C"},
+        ],
     )
-    du.get_team_paths("Team B")["folder"].mkdir(parents=True, exist_ok=True)
-    du.get_team_paths("Team C")["folder"].mkdir(parents=True, exist_ok=True)
+
     teams = du.list_teams()
     assert "Team B" in teams
     assert "TEAM_B" not in teams
     assert set(teams) == {"Team A", "Team B", "TEAM_C"}
 
 
-def test_load_master_creates_file(tmp_path, monkeypatch):
+def test_load_master_empty_when_missing(tmp_path, monkeypatch):
     du = setup_data_utils(tmp_path, monkeypatch)
     team = "My Team"
-    master_path = du.get_team_paths(team)["master"]
-    assert not master_path.exists()
     df = du.load_master(team)
-    assert master_path.exists()
     assert list(df.columns) == du.MASTER_COLUMNS
     assert df.empty
 

--- a/tests/test_teams_store.py
+++ b/tests/test_teams_store.py
@@ -1,31 +1,48 @@
 import sys
 from pathlib import Path
+from importlib import reload
 
 # Ensure application modules can be imported as top-level modules
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "app"))
 
-from teams_store import add_team, list_teams
-import app_paths
 
-def test_add_team_success(tmp_path, monkeypatch):
+def setup_teams_store(tmp_path, monkeypatch):
+    """Return ``teams_store`` using an in-memory mock instead of files."""
     monkeypatch.setattr("app_paths.DATA_DIR", tmp_path, raising=False)
-    from importlib import reload
+
     import teams_store
     reload(teams_store)
 
-    ok, info = teams_store.add_team("Testers")
+    store: list[str] = []
+
+    def fake_load(fp, default):
+        return store or default
+
+    def fake_save(fp, obj):
+        store.clear()
+        store.extend(obj)
+
+    monkeypatch.setattr(teams_store, "_load", fake_load, raising=False)
+    monkeypatch.setattr(teams_store, "_save", fake_save, raising=False)
+
+    # Avoid real Supabase lookups
+    import supabase_client
+    reload(supabase_client)
+    monkeypatch.setattr(supabase_client, "get_client", lambda: object())
+
+    return teams_store
+
+
+def test_add_team_success(tmp_path, monkeypatch):
+    ts = setup_teams_store(tmp_path, monkeypatch)
+    ok, _ = ts.add_team("Testers")
     assert ok is True
-    assert (tmp_path / "teams" / "Testers" / "players.json").exists()
-    assert "Testers" in teams_store.list_teams()
+    assert "Testers" in ts.list_teams()
 
 
 def test_add_team_duplicate(tmp_path, monkeypatch):
-    monkeypatch.setattr("app_paths.DATA_DIR", tmp_path, raising=False)
-    from importlib import reload
-    import teams_store
-    reload(teams_store)
-
-    assert teams_store.add_team("Santos")[0] is True
-    ok, msg = teams_store.add_team("santos")   # case-insensitive
+    ts = setup_teams_store(tmp_path, monkeypatch)
+    assert ts.add_team("Santos")[0] is True
+    ok, msg = ts.add_team("santos")   # case-insensitive
     assert ok is False
     assert "exists" in msg.lower()


### PR DESCRIPTION
## Summary
- Mock Supabase in `test_data_utils` and `test_teams_store` for cloud-style behavior
- Remove filesystem assertions and rely on in-memory storage
- Document Supabase setup and sync utilities usage in README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bc5b5f0eac8320a468c5a2d7189cb9