### PR TITLE
Use environment-based Supabase client configuration

### DIFF
--- a/app/supabase_client.py
+++ b/app/supabase_client.py
@@ -1,23 +1,15 @@
-# supa.py
 from supabase import create_client, Client
+import os
 
-SUPABASE_URL: str = "https://gqiaicnmnoxmqwbeyflp.supabase.co"
-SUPABASE_ANON_KEY: str = (
-    "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9."
-    "eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImdxaWFpY25tbm94bXF3YmV5ZmxwIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTcxNDU4NzcsImV4cCI6MjA3MjcyMTg3N30."
-    "xHFQfCVCX5VhaZgOpRvXLWMHJ3x4huYFubF-CjQxw8U"
-)
 
 def get_client() -> Client:
-    """Palauttaa Supabase clientin ANON-avaimella"""
-    return create_client(SUPABASE_URL, SUPABASE_ANON_KEY)
-
-# Testi että toimii
-if __name__ == "__main__":
-    supabase = get_client()
     try:
-        res = supabase.table("players").select("*").limit(5).execute()
-        print("✅ Supabase-yhteys toimii. Esimerkkidata:")
-        print(res.data)
-    except Exception as e:
-        print("❌ Virhe Supabase-yhteydessä:", e)
+        import streamlit as st
+        url = st.secrets.get("SUPABASE_URL", "") or os.getenv("SUPABASE_URL", "")
+        key = st.secrets.get("SUPABASE_ANON_KEY", "") or os.getenv("SUPABASE_ANON_KEY", "")
+    except Exception:
+        url = os.getenv("SUPABASE_URL", "")
+        key = os.getenv("SUPABASE_ANON_KEY", "")
+    if not url or not key:
+        raise RuntimeError("Supabase secrets missing")
+    return create_client(url, key)


### PR DESCRIPTION
## Summary
- Load Supabase credentials from Streamlit secrets or environment variables
- Fail fast when credentials are missing

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bd06955a7c8320b1d55b28d531c0fa