### PR TITLE
Improve Supabase error handling and data merging robustness

### DIFF
--- a/app/notes.py
+++ b/app/notes.py
@@ -6,8 +6,20 @@ from typing import Any, Dict, List, Optional
 
 import pandas as pd
 import streamlit as st
+import json
+from postgrest.exceptions import APIError
 
 from supabase_client import get_client
+
+def _dbg(e: APIError, title="🔧 Supabase PostgREST -virhe"):
+    with st.expander(title, expanded=True):
+        st.code(
+            f"code: {getattr(e,'code',None)}\n"
+            f"message: {getattr(e,'message',str(e))}\n"
+            f"details: {getattr(e,'details',None)}\n"
+            f"hint: {getattr(e,'hint',None)}",
+            "text",
+        )
 
 # ---------- IO ----------
 @st.cache_data(show_spinner=False)
@@ -15,18 +27,27 @@ def _load_notes() -> List[Dict[str, Any]]:
     client = get_client()
     if not client:
         return []
-    res = client.table("notes").select("*").execute()
-    data = res.data or []
-    return data if isinstance(data, list) else []
+    try:
+        res = client.table("notes").select("*").execute()
+        data = res.data or []
+        return data if isinstance(data, list) else []
+    except APIError as e:
+        _dbg(e)
+        st.error("Notes-haku epäonnistui")
+        return []
 
 
 def _save_notes(data: List[Dict[str, Any]]) -> None:
     client = get_client()
     if not client:
         return
-    client.table("notes").delete().neq("id", None).execute()
-    if data:
-        client.table("notes").insert(data).execute()
+    try:
+        client.table("notes").delete().neq("id", None).execute()
+        if data:
+            client.table("notes").insert(data).execute()
+    except APIError as e:
+        _dbg(e)
+        st.error("Notes-tallennus epäonnistui")
 
 # ---------- Utils ----------
 def _now_iso() -> str:

--- a/app/player_editor.py
+++ b/app/player_editor.py
@@ -26,6 +26,56 @@ from shortlists import (
 # Local directory for player photos
 PLAYER_PHOTOS_DIR = Path("player_photos")
 
+# Canonical column mapping for safe merges
+CANON_MAP = {
+  "PlayerID":"id","player_id":"id","id":"id",
+  "Name":"name","name":"name",
+  "Team":"team_name","team":"team_name","current_club":"team_name","CurrentClub":"team_name","team_name":"team_name",
+  "Position":"position","position":"position","Pos":"position","pos":"position",
+  "DateOfBirth":"date_of_birth","DOB":"date_of_birth","BirthDate":"date_of_birth","birthdate":"date_of_birth","Birthdate":"date_of_birth",
+  "Foot":"preferred_foot","PreferredFoot":"preferred_foot","foot":"preferred_foot","preferred_foot":"preferred_foot",
+  "ClubNumber":"club_number","Number":"club_number","club_number":"club_number",
+  "ScoutRating":"scout_rating","rating":"scout_rating","Scout rating":"scout_rating","scout_rating":"scout_rating",
+  "TransfermarktURL":"transfermarkt_url","transfermarkt":"transfermarkt_url","transfermarkt_url":"transfermarkt_url",
+  "created_at":"created_at","CreatedAt":"created_at"
+}
+CANON_ORDER = ["id","name","team_name","position","date_of_birth","preferred_foot","club_number","scout_rating","transfermarkt_url","created_at"]
+
+
+def canonicalize_dict(d):
+    out={}
+    for k,v in (d or {}).items():
+        if k is None: continue
+        canon = CANON_MAP.get(k,k)
+        if canon not in out or out[canon] in (None,"",pd.NA):
+            out[canon]=v
+    return out
+
+
+def _coalesce_duplicate_columns(df: pd.DataFrame) -> pd.DataFrame:
+    if df is None or df.empty: return df
+    df = df.copy(); df.columns = [CANON_MAP.get(c,c) for c in df.columns]
+    dupes = pd.Index(df.columns)[pd.Index(df.columns).duplicated()].unique()
+    for col in dupes:
+        sub = df.loc[:, df.columns == col]
+        merged = sub.bfill(axis=1).iloc[:,0]
+        df = df.loc[:, df.columns != col]
+        df[col] = merged
+    df = df.loc[:, ~df.columns.duplicated()]
+    lead = [c for c in CANON_ORDER if c in df.columns]
+    rest = [c for c in df.columns if c not in lead]
+    return df[lead+rest]
+
+
+def safe_append_row(df_master: pd.DataFrame, new_row: dict) -> pd.DataFrame:
+    dfm = _coalesce_duplicate_columns(df_master if df_master is not None else pd.DataFrame())
+    row_canon = canonicalize_dict(new_row or {})
+    df_row = _coalesce_duplicate_columns(pd.DataFrame([row_canon]))
+    all_cols = list(dict.fromkeys(list(dfm.columns)+list(df_row.columns)))
+    dfm = dfm.reindex(columns=all_cols); df_row = df_row.reindex(columns=all_cols)
+    out = pd.concat([dfm, df_row], ignore_index=True)
+    return _coalesce_duplicate_columns(out)
+
 # -------------------------------------------------------
 # Yleiset apurit
 # -------------------------------------------------------
@@ -382,7 +432,7 @@ def _render_team_editor_flow(selected_team: str, preselected_name: Optional[str]
             new_id = _new_player_id()
             new_row = {col: "" for col in df_master.columns}
             new_row.update({"PlayerID": new_id, "Name": "New Player"})
-            df_master = pd.concat([df_master, pd.DataFrame([new_row])], ignore_index=True)
+            df_master = safe_append_row(df_master, new_row)
             save_master(df_master, selected_team)
             st.cache_data.clear()
             st.success("First player row created.")
@@ -424,7 +474,7 @@ def _render_team_editor_flow(selected_team: str, preselected_name: Optional[str]
             new_id = _new_player_id()
             new_row = {col: "" for col in df_master.columns}
             new_row.update({"PlayerID": new_id, "Name": "New Player"})
-            df_master = pd.concat([df_master, pd.DataFrame([new_row])], ignore_index=True)
+            df_master = safe_append_row(df_master, new_row)
             save_master(df_master, selected_team)
             st.cache_data.clear()
             st.success("New player row added.")
@@ -669,7 +719,7 @@ def _render_team_editor_flow(selected_team: str, preselected_name: Optional[str]
                 copy = df_master[df_master["PlayerID"]==pid_str].iloc[0].copy()
                 copy["PlayerID"] = _new_player_id()
                 copy["Name"] = f"{copy.get('Name','')} (copy)"
-                df_master = pd.concat([df_master, pd.DataFrame([copy])], ignore_index=True)
+                df_master = safe_append_row(df_master, copy.to_dict())
                 save_master(df_master, selected_team)
                 st.cache_data.clear()
                 st.success("Row duplicated.")
@@ -692,7 +742,7 @@ def _render_team_editor_flow(selected_team: str, preselected_name: Optional[str]
                         new_pid = _new_player_id()
                         row_to_move = row_to_move.copy()
                         row_to_move.loc[:, "PlayerID"] = new_pid
-                        target_master = pd.concat([target_master, row_to_move], ignore_index=True)
+                        target_master = safe_append_row(target_master, row_to_move.iloc[0].to_dict())
                         save_master(target_master, new_team)
                         st.cache_data.clear()
                         st.success(f"Player moved to {new_team}.")

--- a/app/team_view.py
+++ b/app/team_view.py
@@ -2,8 +2,6 @@
 from __future__ import annotations
 from typing import List, Dict, Any, Optional
 from datetime import datetime, date
-from collections import Counter
-
 import pandas as pd
 import streamlit as st
 from postgrest.exceptions import APIError
@@ -25,18 +23,21 @@ STATE_CACHE_BUSTER     = "team_view__cache_buster"
 CARD_THRESHOLD = 80  # korttinäkymän raja
 
 # ========= Helpers =========
-def _pgrest_debug(e: APIError, title="🔧 Supabase PostgREST -virhe (debug)"):
+def _dbg(e: APIError, title="🔧 Supabase PostgREST -virhe"):
     with st.expander(title, expanded=True):
         st.code(
-            f"""code:    {getattr(e,'code',None)}
-message: {getattr(e,'message',str(e))}
-details: {getattr(e,'details',None)}
-hint:    {getattr(e,'hint',None)}""",
-            language="text",
+            f"code: {getattr(e,'code',None)}\n"
+            f"message: {getattr(e,'message',str(e))}\n"
+            f"details: {getattr(e,'details',None)}\n"
+            f"hint: {getattr(e,'hint',None)}",
+            "text",
         )
 
 def _safe_str(v: Any) -> str:
     return "" if v is None else str(v)
+
+def _col(df: pd.DataFrame, name: str, dtype="object") -> pd.Series:
+    return df[name] if name in df.columns else pd.Series(dtype=dtype)
 
 def _norm_team(p: Dict[str, Any]) -> str:
     return (
@@ -114,7 +115,7 @@ def _load_team_names(cache_buster: int) -> List[str]:
         pdata = sb.table("players").select("team_name").execute().data or []
         return sorted({ (p.get("team_name") or "").strip() for p in pdata if (p.get("team_name") or "").strip() })
     except APIError as e:
-        _pgrest_debug(e)
+        _dbg(e)
         return []
     except Exception:
         return []
@@ -126,7 +127,7 @@ def _collect_players_for_team(team: str, cache_buster: int) -> List[Dict[str, An
         res = sb.table("players").select("*").eq("team_name", team).execute()
         players = res.data or []
     except APIError as e:
-        _pgrest_debug(e)
+        _dbg(e)
         return []
     except Exception:
         return []
@@ -154,7 +155,7 @@ def _load_shortlist() -> set:
         return {str(r.get("player_id")) for r in (res.data or []) if r.get("player_id")}
     except APIError as e:
         # Taulu puuttuu → näytä ohje, mutta älä kaadu
-        _pgrest_debug(e, "ℹ️ Shortlist-taulu puuttuu? (debug)")
+        _dbg(e, "ℹ️ Shortlist-taulu puuttuu? (debug)")
         st.info("Shortlist on pois käytöstä, koska taulua `public.shortlists` ei löytynyt.")
         return set()
     except Exception:
@@ -169,7 +170,7 @@ def _save_shortlist(s: set) -> None:
             rows = [{"player_id": str(pid)} for pid in s]
             sb.table("shortlists").insert(rows).execute()
     except APIError as e:
-        _pgrest_debug(e, "ℹ️ Shortlist-talennus epäonnistui (debug)")
+        _dbg(e, "ℹ️ Shortlist-talennus epäonnistui (debug)")
         st.error("Shortlistin tallennus epäonnistui. Luo taulu `public.shortlists` (katso SQL-ohje alla).")
     except Exception:
         pass
@@ -280,16 +281,19 @@ def show_team_view():
     c1, c2, c3 = st.columns(3)
     with c1: st.metric("Players", len(df))
     with c2:
-        pos_counts = Counter((df.get("Position") or pd.Series(dtype=object)).fillna("—").astype(str))
+        pos_s = _col(df, "Position")
+        pos_counts = pos_s.fillna("—").astype(str).value_counts()
         st.metric("Unique positions", len(pos_counts))
     with c3:
-        avg = round(pd.to_numeric(df.get("scout_rating", pd.Series([None]*len(df))), errors="coerce").dropna().mean(), 1) if len(df) else 0
+        rating_s = pd.to_numeric(_col(df, "scout_rating"), errors="coerce")
+        avg = round(rating_s.dropna().mean(), 1) if len(df) else 0
         st.metric("Avg rating", avg if avg == avg else "–")  # NaN check
 
     # Pieni jakauma
-    if "Position" in df.columns and df["Position"].notna().any():
+    pos_chart_s = _col(df, "Position")
+    if pos_chart_s.notna().any():
         st.caption("Position distribution")
-        st.bar_chart(df["Position"].fillna("—").astype(str).value_counts())
+        st.bar_chart(pos_chart_s.fillna("—").astype(str).value_counts())
 
     # --------- Filters ----------
     with st.container():
@@ -297,10 +301,10 @@ def show_team_view():
         with c1:
             q = st.text_input("Search name", key=STATE_Q_KEY, placeholder="e.g. Díaz, González").strip()
         with c2:
-            pos_vals = sorted([v for v in df.get("Position", pd.Series(dtype=object)).dropna().astype(str).unique() if v])
+            pos_vals = sorted([v for v in _col(df, "Position").dropna().astype(str).unique() if v])
             pos_sel = st.multiselect("Position", pos_vals, default=st.session_state.get(STATE_POS_KEY, []), key=STATE_POS_KEY)
         with c3:
-            foot_vals = sorted([v for v in df.get("Foot", pd.Series(dtype=object)).dropna().astype(str).unique() if v])
+            foot_vals = sorted([v for v in _col(df, "Foot").dropna().astype(str).unique() if v])
             foot_sel = st.multiselect("Foot", foot_vals, default=st.session_state.get(STATE_FOOT_KEY, []), key=STATE_FOOT_KEY)
         with c4:
             age_min = age_max = None
@@ -321,7 +325,7 @@ def show_team_view():
                 else:
                     st.caption("No age data")
         with c5:
-            club_vals = sorted([v for v in df.get("CurrentClub", pd.Series(dtype=object)).dropna().astype(str).unique() if v])
+            club_vals = sorted([v for v in _col(df, "CurrentClub").dropna().astype(str).unique() if v])
             club_sel = st.multiselect("Current club", club_vals, default=st.session_state.get(STATE_CLUB_KEY, []), key=STATE_CLUB_KEY)
         with c6:
             if st.button("Reset", help="Clear all filters"):
@@ -378,14 +382,14 @@ def show_team_view():
     # --------- Apply filters ----------
     df_show = df.copy()
     if q: df_show = df_show[df_show["name"].astype(str).str.contains(q, case=False, na=False)]
-    if pos_sel: df_show = df_show[df_show.get("Position", pd.Series(dtype=object)).astype(str).isin(pos_sel)]
-    if foot_sel: df_show = df_show[df_show.get("Foot", pd.Series(dtype=object)).astype(str).isin(foot_sel)]
+    if pos_sel: df_show = df_show[_col(df_show, "Position").astype(str).isin(pos_sel)]
+    if foot_sel: df_show = df_show[_col(df_show, "Foot").astype(str).isin(foot_sel)]
     if (STATE_AGE_KEY in st.session_state) or (age_min is not None and age_max is not None):
         lo, hi = st.session_state.get(STATE_AGE_KEY, (age_min, age_max))
         if lo is not None and hi is not None and "Age" in df_show.columns:
             df_show = df_show[pd.to_numeric(df_show["Age"], errors="coerce").between(lo, hi, inclusive="both")]
     if club_sel:
-        df_show = df_show[df_show.get("CurrentClub", pd.Series(dtype=object)).astype(str).isin(club_sel)]
+        df_show = df_show[_col(df_show, "CurrentClub").astype(str).isin(club_sel)]
 
     st.markdown(f"**Results:** {len(df_show)} / {len(df)}  •  Columns: {len(df_show.columns)}")
 


### PR DESCRIPTION
## Summary
- add `_dbg` helper and APIError handling across pages
- fix Team View column access with `_col` helper
- canonicalize player editor columns to safely append rows
- import json and handle notes and shortlists schema errors

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bd070516308320bc1de99ddf706bde