### PR TITLE
Add login gate to Streamlit app

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -19,6 +19,7 @@ from player_editor import show_player_editor
 from scout_reporter import show_scout_match_reporter
 from notes import show_notes  # varmista, että notes.py sisältää show_notes()
 from shortlists import show_shortlists  # ⭐ uusi sivu
+from login import login
 
 APP_TITLE   = "ScoutLens"
 APP_TAGLINE = "LATAM scouting toolkit"
@@ -38,6 +39,8 @@ def inject_css():
     st.markdown(f"<style>{css}</style>", unsafe_allow_html=True)
 
 inject_css()
+
+login()
 
 # --------- Navigation setup ----------
 # Näkyvät sivut sivupalkissa:

--- a/app/login.py
+++ b/app/login.py
@@ -1,0 +1,18 @@
+import streamlit as st
+
+
+def login():
+    """Simple username/password gate using Streamlit session_state."""
+    if st.session_state.get("authenticated"):
+        return
+
+    username = st.text_input("Username")
+    password = st.text_input("Password", type="password")
+
+    if st.button("Login"):
+        if username == "Santeri" and password == "Volotinen":
+            st.session_state.authenticated = True
+            st.rerun()
+        else:
+            st.error("Invalid username or password")
+    st.stop()


### PR DESCRIPTION
## Summary
- add `login()` module with hard-coded credentials and session-based auth gate
- require `login()` call before navigation so pages load only after authentication

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bd17dd9bd48320b70d1dcd770e39fd