### PR TITLE
Fix Supabase secrets loading in ScoutLens

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -12,23 +12,22 @@ If needed, install Streamlit with:
 
 ### Supabase Sync
 
-Set `SUPABASE_URL` and `SUPABASE_KEY` environment variables to enable
-optional Supabase storage. Functions in `app/sync_utils.py` and
-`app/teams_store.py` will then read and write data to your Supabase tables.
+Configure a `[supabase]` block in your Streamlit secrets to enable optional
+Supabase storage. Functions in `app/sync_utils.py` and `app/teams_store.py`
+will then read and write data to your Supabase tables.
 
 #### Developer Setup
 
 1. Create a project at [Supabase](https://supabase.com) and copy the API URL
-   and service role or anon key from the dashboard.
+   and keys from the dashboard.
 2. Create a storage bucket (for example, `data`) for JSON files.
-3. Export the required environment variables before running ScoutLens or the
-   sync helpers:
+3. Add the credentials to `.streamlit/secrets.toml`:
 
-   ```bash
-   export SUPABASE_URL="https://<project>.supabase.co"
-   export SUPABASE_KEY="<service-role-or-anon-key>"
-   # Optional: set to 1 to force cloud mode
-   export SCOUTLENS_CLOUD=1
+   ```toml
+   [supabase]
+   url = "https://<project>.supabase.co"
+   anon_key = "<public-anon-key>"
+   service_role = "<service-role-key>"  # optional, for sync_utils only
    ```
 
 The application reads and writes JSON data to Supabase storage through

--- a/app/supabase_client.py
+++ b/app/supabase_client.py
@@ -1,15 +1,19 @@
-from typing import Optional
-import os
+from supabase import create_client
 import streamlit as st
-from supabase import create_client, Client
 
-_CACHE: Optional[Client] = None
+_client = None
 
-def get_client() -> Client:
-    global _CACHE
-    if _CACHE:
-        return _CACHE
-    url = st.secrets["supabase"]["url"]
-    key = st.secrets["supabase"].get("anon_key") or os.environ["SUPABASE_ANON_KEY"]
-    _CACHE = create_client(url, key)
-    return _CACHE
+def get_client():
+    global _client
+    if _client is not None:
+        return _client
+
+    try:
+        url = st.secrets["supabase"]["url"]
+        anon_key = st.secrets["supabase"]["anon_key"]
+    except Exception:
+        st.error("Supabase secrets missing. Please add [supabase] block with url + anon_key in Secrets.")
+        st.stop()
+
+    _client = create_client(url, anon_key)
+    return _client

--- a/app/sync_utils.py
+++ b/app/sync_utils.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 import json
-import os
 from pathlib import Path
 
 import streamlit as st
@@ -9,10 +8,9 @@ from supabase import create_client
 
 def _client():
     """Create a Supabase client using service role credentials."""
-    url = os.environ.get("SUPABASE_URL") or st.secrets.get("SUPABASE_URL")
-    key = os.environ.get("SUPABASE_SERVICE_ROLE") or st.secrets.get(
-        "SUPABASE_SERVICE_ROLE"
-    )
+    creds = st.secrets.get("supabase", {})
+    url = creds.get("url")
+    key = creds.get("service_role")
     if not url or not key:
         raise RuntimeError("Supabase credentials not configured")
     return create_client(url, key)


### PR DESCRIPTION
## Summary
- load Supabase client credentials from Streamlit `[supabase]` secrets block and show friendly error if missing
- read sync utility credentials from the same `[supabase]` block
- document secrets-based configuration in README

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bd29b68704832099584f695be391f0