### PR TITLE
codex: fix Supabase insert select misuse

### DIFF
--- a/app/data_utils.py
+++ b/app/data_utils.py
@@ -338,7 +338,11 @@ def insert_player_quick(data: Dict[str, Any]) -> Dict[str, Any]:
     payload["name"] = name
     sb = get_client()
     try:
-        res = sb.table("players").insert(payload).select("*").execute()
+        res = (
+            sb.table("players")
+            .insert(payload, returning="representation")
+            .execute()
+        )
     except APIError as e:
         raise e
     return (res.data or [])[0] if res.data else {}


### PR DESCRIPTION
## Summary
- avoid calling `.select()` on `insert_player_quick`
- use `returning="representation"` to fetch inserted player data

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bd52e87cbc8320872416ee1bfbc374