### PR TITLE
codex: refactor shortlists to Supabase schema

### DIFF
--- a/app/reports_page.py
+++ b/app/reports_page.py
@@ -153,14 +153,7 @@ def show_reports_page() -> None:
                 tm = st.text_input("Transfermarkt URL", key="r_add_tm")
             notes = st.text_area("Notes", key="r_add_notes", height=80)
 
-            b1, b2 = st.columns(2)
-            save = b1.form_submit_button("Save Player", use_container_width=True)
-            full = b2.form_submit_button("Open Full Editor", use_container_width=True)
-
-            if full:
-                st.session_state["current_page"] = "Player Editor"
-                st.session_state["player_editor__mode"] = "new"
-                st.rerun()
+            save = st.form_submit_button("Save Player", use_container_width=True)
 
             if save:
                 try:


### PR DESCRIPTION
## Summary
- refactor shortlists page to use `shortlists` + `shortlist_items` tables
- drop team-centric UI and export club info only
- streamline reports page quick-add player form

## Testing
- `python -m py_compile app/reports_page.py app/shortlists.py app/export_page.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bd567fba708320872b1b0eb72ecc92