### PR TITLE
codex: fix Add Player insert helper

### DIFF
--- a/app/services/__init__.py
+++ b/app/services/__init__.py
@@ -1,0 +1,1 @@
+"""Service layer modules for ScoutLens."""

--- a/app/services/players.py
+++ b/app/services/players.py
@@ -1,0 +1,21 @@
+from typing import Dict, Any, List
+
+from postgrest.exceptions import APIError
+from supabase_client import get_client
+
+
+def insert_player(payload: Dict[str, Any]) -> Dict[str, Any]:
+    """
+    Insert a player and return the inserted row.
+    Uses returning="representation" to avoid a follow-up select.
+    Raises APIError on failure.
+    """
+    sb = get_client()
+    try:
+        resp = sb.table("players").insert(payload, returning="representation").execute()
+        rows: List[Dict[str, Any]] = resp.data or []
+        if not rows:
+            raise RuntimeError("Insert returned no rows")
+        return rows[0]
+    except APIError as e:
+        raise

--- a/app/supabase_client.py
+++ b/app/supabase_client.py
@@ -1,18 +1,13 @@
-# app/supabase_client.py
 from supabase import create_client
 import streamlit as st
 
-def get_client(write: bool = False):
-    """
-    Luo Supabase client.
-    - write=False → käyttää anon_key (SELECT, read-only)
-    - write=True  → käyttää service_role_key (INSERT/UPDATE/DELETE)
-    """
-    url = st.secrets["supabase"]["url"]
+_client = None
 
-    if write:
-        key = st.secrets["supabase"]["service_role_key"]
-    else:
+def get_client():
+    """Return a cached Supabase client using anon key only."""
+    global _client
+    if _client is None:
+        url = st.secrets["supabase"]["url"]
         key = st.secrets["supabase"]["anon_key"]
-
-    return create_client(url, key)
+        _client = create_client(url, key)
+    return _client


### PR DESCRIPTION
## Summary
- use anon Supabase client with simple caching
- add players service for safe insert with returning="representation"
- refactor reports page to reuse service and refresh selection

## Testing
- `python -m py_compile app/supabase_client.py app/services/__init__.py app/services/players.py app/reports_page.py`
- `rg -n "insert\(.*\)\.select\(" app/ || true`


------
https://chatgpt.com/codex/tasks/task_e_68bd601dd0a8832091b6c79de75ef254