### PR TITLE
Fix app module imports for direct execution

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -10,7 +10,13 @@
 
 from __future__ import annotations
 from pathlib import Path
+import sys
 import streamlit as st
+
+# Ensure package imports work when running as `python app/app.py`
+ROOT = Path(__file__).resolve().parent.parent
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
 
 # --- Pages
 from app.reports_page import show_reports_page

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+pythonpath = .


### PR DESCRIPTION
## Summary
- ensure `app/app.py` adjusts `sys.path` so package imports resolve when run directly
- configure pytest to include repository root in `PYTHONPATH`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bd9aa045d88320aba0688710f03703