### PR TITLE
codex: replace deprecated Streamlit APIs

### DIFF
--- a/app/add_player_form.py
+++ b/app/add_player_form.py
@@ -267,13 +267,7 @@ def show_add_player_form():
 
             st.success(f"Pelaaja '{nm}' lisätty joukkueeseen {team}.")
             if save_add_btn:
-                try:
-                    st.rerun()
-                except Exception:
-                    try:
-                        st.experimental_rerun()
-                    except Exception:
-                        pass
+                st.rerun()
 
 if __name__ == "__main__":
     show_add_player_form()

--- a/app/data_manager.py
+++ b/app/data_manager.py
@@ -122,18 +122,17 @@ def show_data_manager():
     df = _to_df(team_players)
 
     st.subheader(f"Players for {team}")
-    editor = getattr(st, "data_editor", None) or getattr(st, "experimental_data_editor", None)
-    if not editor:
+    try:
+        edited = st.data_editor(
+            df,
+            key="dm_players_editor",
+            num_rows="dynamic",
+            use_container_width=True,
+        )
+    except AttributeError:
         st.error("Editable data grid not available in this Streamlit version.")
         st.dataframe(df)
         return
-
-    edited = editor(
-        df,
-        key="dm_players_editor",
-        num_rows="dynamic",
-        use_container_width=True
-    )
 
     # 3) Tallenna muutokset players.jsoniin (korvaa valitun joukkueen rivit)
     if st.button("Save Changes", key="dm_save_players"):

--- a/app/reports_page.py
+++ b/app/reports_page.py
@@ -219,7 +219,7 @@ def show_reports_page() -> None:
         }
         if _insert_report(payload):
             st.success("Report saved")
-            st.experimental_rerun()
+            st.rerun()
 
     st.divider()
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,7 @@
-streamlit
+streamlit>=1.32,<2
 pandas
 numpy
 plotly
 matplotlib
-streamlit>=1.36
 supabase>=2.5.0
 postgrest>=0.15


### PR DESCRIPTION
## Summary
- remove deprecated Streamlit experimental APIs
- update Streamlit dependency to >=1.32,<2

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bdb384511883209883af8b377f6a45