### PR TITLE
codex: replace kickoff_at with report_date in reports flow

### DIFF
--- a/app/reports_page.py
+++ b/app/reports_page.py
@@ -90,16 +90,16 @@ def _list_reports() -> List[Dict[str, Any]]:
     """Return normalized reports with ordering fallbacks."""
     # Prefer VIEW; if schema cache wasn't refreshed yet, fallback to base table
     # Ordering strategy:
-    # 1) Try kickoff_at desc (VIEW provides it via COALESCE)
-    # 2) If that fails (e.g., querying base table without kickoff_at),
+    # 1) Try report_date desc
+    # 2) If that fails (e.g., querying base table without report_date),
     #    retry created_at desc
-    rows = _safe_query("reports", order_by="kickoff_at", desc=True)
+    rows = _safe_query("reports", order_by="report_date", desc=True)
     if not rows:
         rows = _safe_query("reports", order_by="created_at", desc=True)
 
     if not rows:
         # fallback to base table (some envs call scout_reports directly)
-        rows = _safe_query("scout_reports", order_by="kickoff_at", desc=True)
+        rows = _safe_query("scout_reports", order_by="report_date", desc=True)
         if not rows:
             rows = _safe_query("scout_reports", order_by="created_at", desc=True)
 
@@ -113,7 +113,7 @@ def _list_reports() -> List[Dict[str, Any]]:
                 "player_name": r.get("player_name"),
                 "competition": r.get("competition"),
                 "opponent": r.get("opponent"),
-                "kickoff_at": r.get("kickoff_at") or r.get("match_datetime"),
+                "report_date": r.get("report_date") or r.get("match_datetime"),
                 "location": r.get("location"),
                 "ratings": r.get("ratings"),
                 "tags": r.get("tags"),

--- a/supabase/002_reports_view.sql
+++ b/supabase/002_reports_view.sql
@@ -1,5 +1,5 @@
 -- 002_reports_view.sql
--- Normalize reports via a stable VIEW and ensure kickoff_at is available.
+-- Normalize reports via a stable VIEW using report_date only.
 
 -- (A) Minimal base table (safe if exists already)
 create extension if not exists pgcrypto;
@@ -11,7 +11,7 @@ create table if not exists public.scout_reports (
   player_name text,
   competition text,
   opponent text,
-  match_datetime timestamptz,
+  report_date date,
   location text,
   ratings jsonb,
   tags text[],
@@ -20,20 +20,16 @@ create table if not exists public.scout_reports (
   updated_at timestamptz not null default now()
 );
 
--- (B) Optional physical column for kickoff time
-alter table public.scout_reports
-  add column if not exists kickoff_at timestamptz;
-
 -- (C) View with unified columns for the app
 create or replace view public.reports as
 select
   r.id,
-  coalesce(r.title, r.report_title)         as title,
+  coalesce(r.title, r.report_title) as title,
   r.player_id,
   r.player_name,
   r.competition,
   r.opponent,
-  coalesce(r.kickoff_at, r.match_datetime)  as kickoff_at,
+  r.report_date,
   r.location,
   r.ratings,
   r.tags,


### PR DESCRIPTION
## Summary
- order and filter reports by `report_date`
- remove obsolete `kickoff_at` column from SQL view

## Testing
- `pytest -q`
- `rg kickoff_at -n app/reports_page.py`


------
https://chatgpt.com/codex/tasks/task_e_68bdb67024308320895c4b7376702343