### PR TITLE
codex: ensure Streamlit entrypoint uses package imports

### DIFF
--- a/.streamlit/config.toml
+++ b/.streamlit/config.toml
@@ -1,0 +1,2 @@
+[server]
+headless = true

--- a/run.py
+++ b/run.py
@@ -1,0 +1,6 @@
+import runpy
+import sys
+
+# Ensure repository root is on sys.path for package-style imports
+sys.path.insert(0, ".")
+runpy.run_path("app/app.py", run_name="__main__")


### PR DESCRIPTION
## Summary
- add Streamlit config and bootstrap runner so app modules import using `app.*`

## Testing
- `python -m compileall -q app`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bfb26daec08320ba47be24556489bb