### PR TITLE
codex: add PyInstaller-safe login background

### DIFF
--- a/app/login.py
+++ b/app/login.py
@@ -1,39 +1,6 @@
 from __future__ import annotations
-import base64
-from pathlib import Path
 import streamlit as st
-from app.paths import assets_dir
-
-
-def _set_login_background() -> None:
-    img_path: Path = assets_dir() / "login_bg.png"
-    if not img_path.exists():
-        return  # fail silently if image missing
-
-    with img_path.open("rb") as f:
-        b64 = base64.b64encode(f.read()).decode("utf-8")
-
-    st.markdown(
-        f"""
-        <style>
-        .stApp {{
-            background: url("data:image/png;base64,{b64}") center center / cover no-repeat fixed;
-        }}
-        /* soft vignette for readability of form elements */
-        .stApp::before {{
-            content: "";
-            position: fixed;
-            inset: 0;
-            background: radial-gradient(ellipse at 50% 40%, rgba(0,0,0,0.25), rgba(0,0,0,0.55) 70%);
-            pointer-events: none;
-            z-index: 0;
-        }}
-        /* bring content above overlay */
-        .block-container {{ z-index: 1; position: relative; }}
-        </style>
-        """,
-        unsafe_allow_html=True,
-    )
+from app.ui.backgrounds import inject_login_background_css
 
 
 def login() -> None:
@@ -41,7 +8,9 @@ def login() -> None:
     if st.session_state.get("authenticated"):
         return
 
-    _set_login_background()
+    inject_login_background_css(st, "login_bg.png")
+
+    st.markdown('<div class="scoutlens-login-card">', unsafe_allow_html=True)
     st.title("ScoutLens")
 
     username = st.text_input("Username")
@@ -53,4 +22,5 @@ def login() -> None:
             st.rerun()
         else:
             st.error("Invalid username or password")
+    st.markdown("</div>", unsafe_allow_html=True)
     st.stop()

--- a/app/ui/backgrounds.py
+++ b/app/ui/backgrounds.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+import base64
+from pathlib import Path
+import sys
+
+
+def _resource_path(relative: str) -> Path:
+    """Return absolute Path for asset that works in dev, Cloud, PyInstaller."""
+    if hasattr(sys, "_MEIPASS"):
+        base = Path(sys._MEIPASS)  # type: ignore[attr-defined]
+    else:
+        base = Path(__file__).resolve().parents[1]
+    return (base / "assets" / relative).resolve()
+
+
+def _b64_image(path: Path) -> str:
+    return base64.b64encode(path.read_bytes()).decode("utf-8")
+
+
+def inject_login_background_css(st, image_name: str = "login_bg.png") -> None:
+    """Inject CSS to set full-screen background for Login view."""
+    img_path = _resource_path(image_name)
+    if not img_path.exists():
+        st.warning(f"Background image not found: {img_path}")
+        return
+
+    b64 = _b64_image(img_path)
+    css = f"""
+    <style>
+    .stApp {{
+        background: url("data:image/png;base64,{b64}") no-repeat center center fixed;
+        background-size: cover;
+    }}
+
+    .block-container {{
+        background: transparent !important;
+    }}
+
+    .scoutlens-login-card {{
+        background: rgba(0,0,0,0.55);
+        backdrop-filter: blur(4px);
+        border-radius: 12px;
+        padding: 1.25rem;
+        box-shadow: 0 8px 24px rgba(0,0,0,0.35);
+    }}
+
+    .stButton > button,
+    .stTextInput > div > div > input,
+    .stSelectbox,
+    .stRadio {{
+        position: relative;
+        z-index: 2;
+    }}
+    </style>
+    """
+    st.markdown(css, unsafe_allow_html=True)


### PR DESCRIPTION
## Summary
- add `inject_login_background_css` with PyInstaller-safe asset path handling
- wrap login form in styled card and inject background only on login view

## Testing
- `pytest`
- :warning: `pyinstaller --noconfirm --log-level WARN scoutlens.spec` *(PyInstaller not installed; pip install failed with 403)*

------
https://chatgpt.com/codex/tasks/task_e_68bfe34a742883208d84a90ce572ddde