### PR TITLE
codex: add iOS-safe login background

### DIFF
--- a/app/login.py
+++ b/app/login.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 import streamlit as st
-from app.ui.backgrounds import inject_login_background_css
+from app.ui.backgrounds import inject_login_background
 
 
 def login() -> None:
@@ -8,7 +8,7 @@ def login() -> None:
     if st.session_state.get("authenticated"):
         return
 
-    inject_login_background_css(st, "login_bg.png")
+    inject_login_background(st, "login_bg.png")
 
     st.markdown('<div class="scoutlens-login-card">', unsafe_allow_html=True)
     st.title("ScoutLens")

--- a/app/ui/backgrounds.py
+++ b/app/ui/backgrounds.py
@@ -5,11 +5,16 @@ import sys
 
 
 def _resource_path(relative: str) -> Path:
-    """Return absolute Path for asset that works in dev, Cloud, PyInstaller."""
+    """
+    Return absolute path for assets that works in:
+    - normal source run
+    - PyInstaller (sys._MEIPASS)
+    Assets live in app/assets/
+    """
     if hasattr(sys, "_MEIPASS"):
         base = Path(sys._MEIPASS)  # type: ignore[attr-defined]
     else:
-        base = Path(__file__).resolve().parents[1]
+        base = Path(__file__).resolve().parents[1]  # .../app
     return (base / "assets" / relative).resolve()
 
 
@@ -17,40 +22,53 @@ def _b64_image(path: Path) -> str:
     return base64.b64encode(path.read_bytes()).decode("utf-8")
 
 
-def inject_login_background_css(st, image_name: str = "login_bg.png") -> None:
-    """Inject CSS to set full-screen background for Login view."""
+def inject_login_background(st, image_name: str = "login_bg.png") -> None:
+    """
+    iOS-compatible full-screen background.
+    Use ONLY on the Login view.
+    """
     img_path = _resource_path(image_name)
     if not img_path.exists():
         st.warning(f"Background image not found: {img_path}")
         return
 
     b64 = _b64_image(img_path)
-    css = f"""
-    <style>
-    .stApp {{
-        background: url("data:image/png;base64,{b64}") no-repeat center center fixed;
-        background-size: cover;
-    }}
 
-    .block-container {{
-        background: transparent !important;
-    }}
+    st.markdown(
+        f"""
+        <style>
+        /* Fixed background layer (iOS-safe: no background-attachment) */
+        #scoutlens-bg {{
+            position: fixed;
+            inset: 0;
+            z-index: 0;
+            background-image: url("data:image/png;base64,{b64}");
+            background-position: center center;
+            background-repeat: no-repeat;
+            background-size: cover;
+        }}
 
-    .scoutlens-login-card {{
-        background: rgba(0,0,0,0.55);
-        backdrop-filter: blur(4px);
-        border-radius: 12px;
-        padding: 1.25rem;
-        box-shadow: 0 8px 24px rgba(0,0,0,0.35);
-    }}
+        /* Ensure app content sits above and stays transparent */
+        [data-testid="stAppViewContainer"] > .main {{
+            position: relative;
+            z-index: 1;
+            background: transparent !important;
+        }}
 
-    .stButton > button,
-    .stTextInput > div > div > input,
-    .stSelectbox,
-    .stRadio {{
-        position: relative;
-        z-index: 2;
-    }}
-    </style>
-    """
-    st.markdown(css, unsafe_allow_html=True)
+        /* Optional: cleaner header on Login */
+        [data-testid="stHeader"] {{ background: transparent; }}
+
+        /* Readable login card on top of image */
+        .scoutlens-login-card {{
+            background: rgba(0,0,0,0.55);
+            backdrop-filter: blur(4px);
+            border-radius: 12px;
+            padding: 1.25rem;
+            box-shadow: 0 8px 24px rgba(0,0,0,0.35);
+        }}
+        </style>
+        <div id="scoutlens-bg" aria-hidden="true"></div>
+        """,
+        unsafe_allow_html=True,
+    )
+


### PR DESCRIPTION
## Summary
- add iOS-safe `inject_login_background` helper using a fixed layer instead of `background-attachment`
- use the helper on the Login page to show `login_bg.png`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bfe56630dc83208b7f9a889d34756b