### PR TITLE
codex: bundle assets for login background

### DIFF
--- a/scoutlens.spec
+++ b/scoutlens.spec
@@ -1,4 +1,5 @@
 # -*- mode: python ; coding: utf-8 -*-
+from PyInstaller.utils.hooks import Tree
 
 block_cipher = None
 
@@ -7,7 +8,7 @@ a = Analysis(
     ['app/app.py'],
     pathex=[],
     binaries=[],
-    datas=[('assets/login_bg.png', 'assets')],
+    datas=Tree('assets', prefix='assets'),
     hiddenimports=[],
     hookspath=[],
     hooksconfig={},


### PR DESCRIPTION
## Summary
- include entire `assets` directory when building PyInstaller bundle so login background is packaged

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c029f20bac8320b6bd12420eeaa95b