### PR TITLE
Add flexible login background asset lookup

### DIFF
--- a/app/login.py
+++ b/app/login.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 import streamlit as st
-from app.utils.assets import get_asset_path, set_page_bg
+from app.ui.login_bg import set_login_background
 
 
 def login() -> None:
@@ -8,7 +8,7 @@ def login() -> None:
     if st.session_state.get("authenticated"):
         return
 
-    set_page_bg(get_asset_path("login_bg.png"))
+    set_login_background("login_bg.png", opacity=0.30)
 
     st.markdown(
         """

--- a/app/ui/login_bg.py
+++ b/app/ui/login_bg.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+import sys
+from pathlib import Path
+from base64 import b64encode
+import streamlit as st
+
+
+def _bundle_base() -> Path:
+    # PyInstaller support
+    if hasattr(sys, "_MEIPASS"):
+        return Path(sys._MEIPASS)
+    # repo/dev root: this file is app/ui/login_bg.py -> go two levels up
+    return Path(__file__).resolve().parents[2]
+
+
+def _candidate_paths(name_or_path: str) -> list[Path]:
+    base = _bundle_base()
+    p = Path(name_or_path)
+    cand = [
+        base / "app" / "assets" / p.name,
+        base / "assets" / p.name,
+        p if p.is_absolute() else base / p,
+    ]
+    # De-duplicate while preserving order
+    seen = set()
+    uniq: list[Path] = []
+    for c in cand:
+        if c not in seen:
+            uniq.append(c)
+            seen.add(c)
+    return uniq
+
+
+@st.cache_data(show_spinner=False)
+def _read_image_b64(p: Path) -> str:
+    return b64encode(p.read_bytes()).decode("ascii")
+
+
+def set_login_background(image: str = "login_bg.png", opacity: float = 0.25) -> None:
+    tried = _candidate_paths(image)
+    img_path = next((p for p in tried if p.exists()), None)
+    if not img_path:
+        tried_str = "\n - " + "\n - ".join(str(p) for p in tried)
+        st.warning(f"Login background not found. Tried:{tried_str}")
+        return
+
+    b64 = _read_image_b64(img_path)
+    css = f"""
+    <style>
+      [data-testid="stAppViewContainer"]::before {{
+        content: "";
+        position: fixed;
+        inset: 0;
+        background-image: url("data:image/png;base64,{b64}");
+        background-position: center;
+        background-repeat: no-repeat;
+        background-size: cover;
+        background-attachment: fixed;
+        opacity: {opacity};
+        z-index: -1;
+      }}
+      @supports (-webkit-touch-callout: none) {{
+        [data-testid="stAppViewContainer"]::before {{
+          background-attachment: scroll;
+          position: absolute;
+        }}
+      }}
+      .login-panel {{
+        background: rgba(0,0,0,0.35);
+        backdrop-filter: blur(4px);
+        border-radius: 16px;
+        padding: 1.25rem;
+      }}
+    </style>
+    """
+    st.markdown(css, unsafe_allow_html=True)

--- a/scoutlens.spec
+++ b/scoutlens.spec
@@ -8,7 +8,10 @@ a = Analysis(
     ['app/app.py'],
     pathex=[],
     binaries=[],
-    datas=Tree('assets', prefix='assets'),
+    datas=(
+        Tree('assets', prefix='assets')
+        + Tree('app/assets', prefix='app/assets')
+    ),
     hiddenimports=[],
     hookspath=[],
     hooksconfig={},


### PR DESCRIPTION
## Summary
- Support login background lookup in `app/assets` and root `assets` with PyInstaller compatibility
- Use `set_login_background` on login page
- Include asset folders in PyInstaller bundle

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c02e60a45883208da8cd1d31ce2d9d