### PR TITLE
codex: make login background transparent

### DIFF
--- a/app/login.py
+++ b/app/login.py
@@ -11,6 +11,11 @@ def login() -> None:
     set_login_background("login_bg.png", opacity=0.30)
 
     st.markdown(
+        "<style>html, body, .stApp { background: transparent !important; }</style>",
+        unsafe_allow_html=True,
+    )
+
+    st.markdown(
         """
         <style>
         .login-card {


### PR DESCRIPTION
## Summary
- inject CSS after setting login background so html/body/.stApp are transparent

## Testing
- `pytest`
- `python -m py_compile app/login.py`
- `streamlit run app/app.py` *(cannot verify UI in headless environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c04149270083208c961a621adfd65e