### PR TITLE
Fix theme import for Streamlit

### DIFF
--- a/app/theme.py
+++ b/app/theme.py
@@ -1,14 +1,13 @@
 from pathlib import Path
-
 import streamlit as st
 
 
 def use_theme() -> None:
-    """Inject global ScoutLens theme CSS."""
+    """Inject global CSS theme once per run."""
     css_path = Path(__file__).with_name("theme.css")
-    css = css_path.read_text(encoding="utf-8")
-    st.markdown(f"<style>{css}</style>", unsafe_allow_html=True)
-
-
-__all__ = ["use_theme"]
+    if css_path.exists():
+        st.markdown(
+            f"<style>{css_path.read_text(encoding='utf-8')}</style>",
+            unsafe_allow_html=True,
+        )
 


### PR DESCRIPTION
## Summary
- guard global CSS theme loader and ensure import works with missing theme.css

## Testing
- `streamlit run app/app.py --server.headless true`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c0f1e0f7e48320a11f4dcc64af9749