### PR TITLE
codex: fix Streamlit entrypoint imports

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,2 @@
+run:
+	streamlit run app/main.py

--- a/README.txt
+++ b/README.txt
@@ -14,7 +14,7 @@ If needed, install Streamlit with:
 
 From the project root run:
 
-    streamlit run app/app.py
+    streamlit run app/main.py
 
 You can verify the package imports with:
 

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,1 +1,2 @@
-# package marker
+"""ScoutLens app package."""
+

--- a/app/main.py
+++ b/app/main.py
@@ -1,4 +1,4 @@
-# app/app.py
+# app/main.py
 # =============================================================================
 # ScoutLens — App shell with polished sidebar navigation (stable across reruns)
 # - Single-source-of-truth nav (st.session_state["nav_page"])
@@ -12,9 +12,9 @@ from __future__ import annotations
 from pathlib import Path
 import sys
 import streamlit as st
-from .theme import use_theme
+from app.theme import use_theme
 
-# Ensure package imports work when running as `python app/app.py`
+# Ensure package imports work when running as `python app/main.py`
 ROOT = Path(__file__).resolve().parent.parent
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
@@ -86,8 +86,7 @@ def _on_nav_change() -> None:
 
 
 def main() -> None:
-    # Page config must be first Streamlit call
-    st.set_page_config(page_title=APP_TITLE, layout="wide")
+    use_theme(APP_TITLE)
 
     # Temporary cache bust during Supabase client upgrade
     try:
@@ -97,7 +96,6 @@ def main() -> None:
         pass
 
     inject_css()
-    use_theme()
     login()
 
     # --------- Init from URL once ----------

--- a/app/theme.py
+++ b/app/theme.py
@@ -2,8 +2,9 @@ from pathlib import Path
 import streamlit as st
 
 
-def use_theme() -> None:
-    """Inject global CSS theme once per run."""
+def use_theme(page_title: str = "ScoutLens") -> None:
+    """Apply page config and inject global CSS theme once per run."""
+    st.set_page_config(page_title=page_title, layout="wide")
     css_path = Path(__file__).with_name("theme.css")
     if css_path.exists():
         st.markdown(

--- a/run.py
+++ b/run.py
@@ -3,4 +3,4 @@ import sys
 
 # Ensure repository root is on sys.path for package-style imports
 sys.path.insert(0, ".")
-runpy.run_path("app/app.py", run_name="__main__")
+runpy.run_path("app/main.py", run_name="__main__")

--- a/run.sh
+++ b/run.sh
@@ -6,4 +6,4 @@ echo "📦 Installing dependencies..."
 pip install -r requirements.txt
 
 echo "🚀 Starting Streamlit app..."
-streamlit run app/app.py
+streamlit run app/main.py

--- a/scoutlens.spec
+++ b/scoutlens.spec
@@ -5,7 +5,7 @@ block_cipher = None
 
 
 a = Analysis(
-    ['app/app.py'],
+    ['app/main.py'],
     pathex=[],
     binaries=[],
     datas=(


### PR DESCRIPTION
## Summary
- rename app/app.py to app/main.py and switch to absolute theme import
- move page config into app.theme.use_theme
- point README, Makefile, run scripts and build spec to streamlit run app/main.py

## Testing
- `python -c "import app, app.theme; print('ok')"`
- `timeout 10 streamlit run app/main.py --server.headless true`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c0f5002ef08320af4107834c000d24