### PR TITLE
codex: collapse sidebar on navigation

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 from pathlib import Path
 import sys
 import streamlit as st
+from app.ui import bootstrap_sidebar_auto_collapse
 
 st.set_page_config(
     page_title="ScoutLens",
@@ -19,27 +20,7 @@ st.set_page_config(
     initial_sidebar_state="expanded",
 )
 
-
-def collapse_sidebar_on_next_rerun() -> None:
-    st.session_state._collapse_sidebar = True
-    st.rerun()
-
-
-if st.session_state.get("_collapse_sidebar"):
-    st.session_state._collapse_sidebar = False
-    st.markdown(
-        """
-        <script>
-        const tryClose = () => {
-          // Streamlit header hamburger button
-          const btn = window.parent.document.querySelector('button[kind="headerNoPadding"]');
-          if (btn) { btn.click(); } else { setTimeout(tryClose, 50); }
-        };
-        tryClose();
-        </script>
-        """,
-        unsafe_allow_html=True,
-    )
+bootstrap_sidebar_auto_collapse()
 
 
 # Ensure package imports work when running as `python app/app.py`
@@ -165,9 +146,10 @@ def main() -> None:
     prev = st.session_state.get("_prev_nav")
     if prev != page:
         st.session_state["_prev_nav"] = page
+        st.session_state["_collapse_sidebar"] = True
         st.session_state["nav_page"] = page
         _sync_query(page)
-        collapse_sidebar_on_next_rerun()
+        st.stop()
 
     current_page = st.session_state.get("nav_page", NAV_KEYS[0])
 

--- a/app/export_page.py
+++ b/app/export_page.py
@@ -10,9 +10,13 @@ from __future__ import annotations
 import pandas as pd
 import streamlit as st
 from postgrest.exceptions import APIError
+from app.ui import bootstrap_sidebar_auto_collapse
 
 from app.supabase_client import get_client
 from app.db_tables import REPORTS
+
+
+bootstrap_sidebar_auto_collapse()
 
 
 def _fetch_export_rows():

--- a/app/home.py
+++ b/app/home.py
@@ -15,6 +15,7 @@ from postgrest.exceptions import APIError
 from app.supabase_client import get_client
 from app.time_utils import to_tz
 from app.db_tables import PLAYERS, SCOUT_REPORTS, NOTES, MATCHES
+from app.ui import bootstrap_sidebar_auto_collapse
 
 
 # ---------------- Utilities ----------------
@@ -38,6 +39,9 @@ def _get_app_tz() -> ZoneInfo:
 
 
 APP_TZ = _get_app_tz()
+
+
+bootstrap_sidebar_auto_collapse()
 
 
 def _ensure_aware(dt: datetime | None, default_tz: ZoneInfo) -> datetime | None:

--- a/app/inspect_player.py
+++ b/app/inspect_player.py
@@ -5,8 +5,12 @@ from __future__ import annotations
 import pandas as pd
 import streamlit as st
 from postgrest.exceptions import APIError
+from app.ui import bootstrap_sidebar_auto_collapse
 
 from app.supabase_client import get_client
+
+
+bootstrap_sidebar_auto_collapse()
 
 
 def show_inspect_player() -> None:

--- a/app/login.py
+++ b/app/login.py
@@ -9,8 +9,10 @@ from datetime import datetime, timedelta, timezone
 from typing import Dict, Optional, Tuple
 
 import streamlit as st
-
+from app.ui import bootstrap_sidebar_auto_collapse
 from app.ui.login_bg import set_login_background
+
+bootstrap_sidebar_auto_collapse()
 
 
 # ============================

--- a/app/notes.py
+++ b/app/notes.py
@@ -9,8 +9,12 @@ import pandas as pd
 import streamlit as st
 import json
 from postgrest.exceptions import APIError
+from app.ui import bootstrap_sidebar_auto_collapse
 
 from app.supabase_client import get_client
+
+
+bootstrap_sidebar_auto_collapse()
 
 def _dbg(e: APIError, title="🔧 Supabase PostgREST -virhe"):
     with st.expander(title, expanded=True):

--- a/app/player_editor.py
+++ b/app/player_editor.py
@@ -10,6 +10,7 @@ import pandas as pd
 import numpy as np
 import streamlit as st
 import traceback
+from app.ui import bootstrap_sidebar_auto_collapse
 
 # --- Supabase & data helpers ---
 from app.supabase_client import get_client
@@ -42,6 +43,9 @@ CANON_MAP = {
   "created_at":"created_at","CreatedAt":"created_at"
 }
 CANON_ORDER = ["id","name","team_name","position","date_of_birth","preferred_foot","club_number","scout_rating","transfermarkt_url","created_at"]
+
+
+bootstrap_sidebar_auto_collapse()
 
 
 def _save_master_sanitized(df: pd.DataFrame, team: str) -> None:

--- a/app/reports_page.py
+++ b/app/reports_page.py
@@ -17,10 +17,14 @@ from typing import Any, Dict, List, Callable
 import pandas as pd
 import streamlit as st
 from postgrest.exceptions import APIError
+from app.ui import bootstrap_sidebar_auto_collapse
 
 from app.supabase_client import get_client
 from app.db_tables import PLAYERS
 from app.services.players import insert_player
+
+
+bootstrap_sidebar_auto_collapse()
 
 
 POSITIONS = [

--- a/app/scout_reporter.py
+++ b/app/scout_reporter.py
@@ -11,12 +11,16 @@ import pandas as pd
 import streamlit as st
 import plotly.express as px
 import traceback
+from app.ui import bootstrap_sidebar_auto_collapse
 
 from app.supabase_client import get_client
 from app.data_utils import list_teams, list_players_by_team  # käyttää Supabasea
 from app.time_utils import to_tz
 from app.data_sanitize import clean_jsonable
 from app.db_tables import MATCHES, SCOUT_REPORTS, SHORTLISTS
+
+
+bootstrap_sidebar_auto_collapse()
 
 REQUIRED_COLS = [
     "id",

--- a/app/shortlists_page.py
+++ b/app/shortlists_page.py
@@ -5,8 +5,12 @@ from __future__ import annotations
 import pandas as pd
 import streamlit as st
 from postgrest.exceptions import APIError
+from app.ui import bootstrap_sidebar_auto_collapse
 
 from app.supabase_client import get_client
+
+
+bootstrap_sidebar_auto_collapse()
 
 
 def show_shortlists_page() -> None:

--- a/app/ui/__init__.py
+++ b/app/ui/__init__.py
@@ -1,0 +1,42 @@
+"""UI helpers shared across ScoutLens pages."""
+
+from __future__ import annotations
+
+import streamlit as st
+
+
+def bootstrap_sidebar_auto_collapse() -> None:
+    """If session flag is set, click the header hamburger to close sidebar once."""
+    if st.session_state.get("_collapse_sidebar"):
+        st.session_state._collapse_sidebar = False
+        st.markdown(
+            """
+            <script>
+            // Use multiple selectors because Streamlit header DOM changes occasionally
+            const selectors = [
+              'button[aria-label="Main menu"]',
+              'button[title="Main menu"]',
+              'button[kind="headerNoPadding"]',
+              'button[data-testid="baseButton-headerNoPadding"]'
+            ];
+            function findToggleBtn() {
+              const root = window.parent?.document || document;
+              for (const sel of selectors) {
+                const btn = root.querySelector(sel);
+                if (btn) return btn;
+              }
+              const header = (window.parent?.document || document).querySelector('header');
+              if (header) return header.querySelector('button');
+              return null;
+            }
+            function tryClose(attempt=0) {
+              const btn = findToggleBtn();
+              if (btn) { btn.click(); }
+              else if (attempt < 40) { setTimeout(() => tryClose(attempt + 1), 50); }
+            }
+            tryClose();
+            </script>
+            """,
+            unsafe_allow_html=True,
+        )
+


### PR DESCRIPTION
## Summary
- add `bootstrap_sidebar_auto_collapse` helper to reliably toggle Streamlit's menu button
- call helper across all pages and update router to auto-hide sidebar after page change

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c11691cec483209e0d0a40f783f0e4