### PR TITLE
codex: use relative imports for UI helper

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -18,7 +18,7 @@ ROOT = Path(__file__).resolve().parent.parent
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
-from app.ui import bootstrap_sidebar_auto_collapse
+from .ui import bootstrap_sidebar_auto_collapse
 
 st.set_page_config(
     page_title="ScoutLens",

--- a/app/export_page.py
+++ b/app/export_page.py
@@ -10,10 +10,10 @@ from __future__ import annotations
 import pandas as pd
 import streamlit as st
 from postgrest.exceptions import APIError
-from app.ui import bootstrap_sidebar_auto_collapse
+from .ui import bootstrap_sidebar_auto_collapse
 
-from app.supabase_client import get_client
-from app.db_tables import REPORTS
+from .supabase_client import get_client
+from .db_tables import REPORTS
 
 
 bootstrap_sidebar_auto_collapse()

--- a/app/home.py
+++ b/app/home.py
@@ -12,10 +12,10 @@ import os
 import pandas as pd
 import streamlit as st
 from postgrest.exceptions import APIError
-from app.supabase_client import get_client
-from app.time_utils import to_tz
-from app.db_tables import PLAYERS, SCOUT_REPORTS, NOTES, MATCHES
-from app.ui import bootstrap_sidebar_auto_collapse
+from .supabase_client import get_client
+from .time_utils import to_tz
+from .db_tables import PLAYERS, SCOUT_REPORTS, NOTES, MATCHES
+from .ui import bootstrap_sidebar_auto_collapse
 
 
 # ---------------- Utilities ----------------

--- a/app/inspect_player.py
+++ b/app/inspect_player.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import pandas as pd
 import streamlit as st
 from postgrest.exceptions import APIError
-from app.ui import bootstrap_sidebar_auto_collapse
+from .ui import bootstrap_sidebar_auto_collapse
 
 from app.supabase_client import get_client
 

--- a/app/login.py
+++ b/app/login.py
@@ -9,7 +9,7 @@ from datetime import datetime, timedelta, timezone
 from typing import Dict, Optional, Tuple
 
 import streamlit as st
-from app.ui import bootstrap_sidebar_auto_collapse
+from .ui import bootstrap_sidebar_auto_collapse
 from app.ui.login_bg import set_login_background
 
 bootstrap_sidebar_auto_collapse()

--- a/app/notes.py
+++ b/app/notes.py
@@ -9,9 +9,9 @@ import pandas as pd
 import streamlit as st
 import json
 from postgrest.exceptions import APIError
-from app.ui import bootstrap_sidebar_auto_collapse
+from .ui import bootstrap_sidebar_auto_collapse
 
-from app.supabase_client import get_client
+from .supabase_client import get_client
 
 
 bootstrap_sidebar_auto_collapse()

--- a/app/player_editor.py
+++ b/app/player_editor.py
@@ -10,7 +10,7 @@ import pandas as pd
 import numpy as np
 import streamlit as st
 import traceback
-from app.ui import bootstrap_sidebar_auto_collapse
+from .ui import bootstrap_sidebar_auto_collapse
 
 # --- Supabase & data helpers ---
 from app.supabase_client import get_client

--- a/app/reports_page.py
+++ b/app/reports_page.py
@@ -17,7 +17,7 @@ from typing import Any, Dict, List, Callable
 import pandas as pd
 import streamlit as st
 from postgrest.exceptions import APIError
-from app.ui import bootstrap_sidebar_auto_collapse
+from .ui import bootstrap_sidebar_auto_collapse
 
 from app.supabase_client import get_client
 from app.db_tables import PLAYERS

--- a/app/scout_reporter.py
+++ b/app/scout_reporter.py
@@ -11,13 +11,13 @@ import pandas as pd
 import streamlit as st
 import plotly.express as px
 import traceback
-from app.ui import bootstrap_sidebar_auto_collapse
+from .ui import bootstrap_sidebar_auto_collapse
 
-from app.supabase_client import get_client
-from app.data_utils import list_teams, list_players_by_team  # käyttää Supabasea
-from app.time_utils import to_tz
-from app.data_sanitize import clean_jsonable
-from app.db_tables import MATCHES, SCOUT_REPORTS, SHORTLISTS
+from .supabase_client import get_client
+from .data_utils import list_teams, list_players_by_team  # käyttää Supabasea
+from .time_utils import to_tz
+from .data_sanitize import clean_jsonable
+from .db_tables import MATCHES, SCOUT_REPORTS, SHORTLISTS
 
 
 bootstrap_sidebar_auto_collapse()

--- a/app/shortlists_page.py
+++ b/app/shortlists_page.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import pandas as pd
 import streamlit as st
 from postgrest.exceptions import APIError
-from app.ui import bootstrap_sidebar_auto_collapse
+from .ui import bootstrap_sidebar_auto_collapse
 
 from app.supabase_client import get_client
 


### PR DESCRIPTION
## Summary
- avoid ImportError by importing `bootstrap_sidebar_auto_collapse` via relative package path
- update app modules to use package-relative imports for shared UI helper

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c13d9422d48320adea4efde0ad86fd