### PR TITLE
codex: use absolute import in Streamlit app

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -13,12 +13,13 @@ from pathlib import Path
 import sys
 import streamlit as st
 
-# Ensure package imports work when running as `python app/app.py`
+# Ensure package imports work when running from source
 ROOT = Path(__file__).resolve().parent.parent
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
-from .ui import bootstrap_sidebar_auto_collapse
+# Use absolute import so Streamlit executes the file cleanly
+from app.ui import bootstrap_sidebar_auto_collapse
 
 st.set_page_config(
     page_title="ScoutLens",


### PR DESCRIPTION
## Summary
- fix Streamlit app bootstrap by switching to absolute import

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c1407070488320afcf47eb17c62561