### PR TITLE
codex: show signed-in user info in sidebar

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -42,6 +42,7 @@ show_inspect_player = _safe_import("inspect player", "app.inspect_player", "show
 show_shortlists_page= _safe_import("shortlists",     "app.shortlists_page","show_shortlists_page")
 show_export_page    = _safe_import("export",         "app.export_page",    "show_export_page")
 login               = _safe_import("login",          "app.login",          "login")
+logout              = _safe_import("logout",         "app.login",          "logout")
 
 APP_TITLE   = "ScoutLens"
 APP_TAGLINE = "LATAM scouting toolkit"
@@ -111,6 +112,16 @@ def main() -> None:
             label_visibility="collapsed",
             on_change=lambda: go(st.session_state["_nav_radio"]),
         )
+
+        auth = st.session_state.get("auth", {})
+        user = auth.get("user")
+        if auth.get("authenticated") and user:
+            name = user.get("name") or user.get("username", "")
+            st.markdown(
+                f"<div class='sb-user'>Signed in as {name}</div>",
+                unsafe_allow_html=True,
+            )
+            st.button("Sign out", on_click=logout)
 
         st.markdown(
             f"<div class='sb-footer'><strong>{APP_TITLE}</strong> v{APP_VERSION}</div>",

--- a/app/styles/sidebar.css
+++ b/app/styles/sidebar.css
@@ -63,6 +63,11 @@ section[data-testid="stSidebar"] a:hover {
   color: color-mix(in srgb, var(--fg-strong) 85%, var(--accent-1) 15%);
 }
 
+.sb-user {
+  margin: var(--space-4) 0 var(--space-2);
+  font-size: var(--text-sm);
+}
+
 /* Liikettä vähentäville käyttäjille: poista siirtymät/siirrot */
 @media (prefers-reduced-motion: reduce) {
   section[data-testid="stSidebar"] [role="radiogroup"] > label {


### PR DESCRIPTION
## Summary
- display signed-in user and sign-out button in sidebar
- add sidebar style for user info line

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c4e4f03c88832080f3ed1a922c2720