### PR TITLE
codex: expand typography scale

### DIFF
--- a/app/login.py
+++ b/app/login.py
@@ -178,7 +178,7 @@ def login(
           box-shadow: 0 4px 20px rgba(0,0,0,.18); padding: 22px 20px;
         }
         div[data-testid="stForm"] > div { padding: 0 !important; }
-        .form-title { color: #e2e8f0; margin: 0 0 8px 0; font-weight: 700; font-size: 1.35rem; }
+        .form-title { color: #e2e8f0; margin: 0 0 8px 0; font-weight: 700; font-size: var(--fs-20); }
         .stTextInput > div > div > input {
           background: rgba(2,6,23,.80);
           border: 1px solid rgba(255,255,255,.10);
@@ -200,14 +200,14 @@ def login(
 
         @media (min-width: 1200px) and (max-width: 2400px) and (min-aspect-ratio: 1/1.3) and (max-aspect-ratio: 5/4) {
           div[data-testid="stForm"] { max-width: 620px; padding: 28px 24px; border-radius: 16px; }
-          .form-title { font-size: 1.5rem; }
-          .stTextInput > div > div > input { font-size: 16px; padding: 12px 14px; }
-          .stButton button { font-size: 16px; padding: 12px 16px; border-radius: 14px; }
+          .form-title { font-size: var(--fs-24); }
+          .stTextInput > div > div > input { font-size: var(--fs-16); padding: 12px 14px; }
+          .stButton button { font-size: var(--fs-16); padding: 12px 16px; border-radius: 14px; }
         }
 
         @media (max-width: 540px) {
           div[data-testid="stForm"] { max-width: 94vw; padding: 18px 16px; border-radius: 10px; }
-          .form-title { font-size: 1.2rem; }
+          .form-title { font-size: var(--fs-16); }
         }
 
         @media (max-height: 520px) and (orientation: landscape) {

--- a/app/player_preview.py
+++ b/app/player_preview.py
@@ -220,12 +220,12 @@ def _ratings_to_df(ratings) -> pd.DataFrame:
 BADGE_CSS = """
 <style>
 .badges { display:flex; gap:.5rem; flex-wrap:wrap; }
-.badge  { padding:.25rem .6rem; border-radius:999px; font-size:.85rem; font-weight:600;
+.badge  { padding:.25rem .6rem; border-radius:999px; font-size:var(--fs-14); font-weight:600;
           background:rgba(255,255,255,.08); border:1px solid rgba(255,255,255,.15); }
 .kpi    { background:rgba(255,255,255,.04); border:1px solid rgba(255,255,255,.08);
           padding:12px 14px; border-radius:12px; }
-.kpi h4 { margin:0 0 6px 0; font-size:.9rem; opacity:.8; }
-.kpi .val{ font-size:1.6rem; font-weight:700; }
+.kpi h4 { margin:0 0 6px 0; font-size:var(--fs-14); opacity:.8; }
+.kpi .val{ font-size:var(--fs-24); font-weight:700; }
 </style>
 """
 

--- a/app/scout_reporter.py
+++ b/app/scout_reporter.py
@@ -264,13 +264,13 @@ CORE_AREAS = [
 BADGE_CSS = """
 <style>
 .badges { display:flex; gap:.5rem; flex-wrap:wrap; }
-.badge  { padding:.25rem .6rem; border-radius:999px; font-size:.85rem; font-weight:600;
+.badge  { padding:.25rem .6rem; border-radius:999px; font-size:var(--fs-14); font-weight:600;
           background:rgba(255,255,255,.08); border:1px solid rgba(255,255,255,.15); }
 .kpi    { background:rgba(255,255,255,.04); border:1px solid rgba(255,255,255,.08);
           padding:12px 14px; border-radius:12px; }
-.kpi h4 { margin:0 0 6px 0; font-size:.9rem; opacity:.8; }
-.kpi .val{ font-size:1.6rem; font-weight:700; }
-.small  { opacity:.8; font-size:.9rem; }
+.kpi h4 { margin:0 0 6px 0; font-size:var(--fs-14); opacity:.8; }
+.kpi .val{ font-size:var(--fs-24); font-weight:700; }
+.small  { opacity:.8; font-size:var(--fs-14); }
 </style>
 """
 

--- a/app/styles/components.css
+++ b/app/styles/components.css
@@ -1,7 +1,7 @@
 /* Cards & KPI */
 .sl-kpi { text-align:left; }
 .sl-kpi .label { font-size: var(--fs-14); color: var(--fg-muted); }
-.sl-kpi .value { font-size: var(--fs-28); font-weight:700; }
+.sl-kpi .value { font-size: var(--fs-32); font-weight:700; }
 
 /* Buttons */
 .stButton>button, .sl-btn {

--- a/app/styles/layout.css
+++ b/app/styles/layout.css
@@ -3,7 +3,14 @@ html, body, .stApp {
   color: var(--fg-strong);
   font-family: var(--font-sans);
   line-height: var(--lh-relaxed);
+  font-size: var(--fs-16);
 }
+
+h1 { font-size: var(--fs-32); line-height: var(--lh-tight); }
+h2 { font-size: var(--fs-28); line-height: var(--lh-tight); }
+h3 { font-size: var(--fs-24); line-height: var(--lh-tight); }
+h4 { font-size: var(--fs-20); line-height: var(--lh-tight); }
+h5 { font-size: var(--fs-16); line-height: var(--lh-tight); }
 
 .stApp [data-testid="stHeader"]{
   background: transparent;

--- a/app/styles/sidebar.css
+++ b/app/styles/sidebar.css
@@ -64,9 +64,9 @@ section[data-testid="stSidebar"] a:hover {
 }
 
 .sb-user {
-  margin: var(--space-4) 0 var(--space-2);
-  font-size: var(--text-sm);
-}
+    margin: var(--space-4) 0 var(--space-2);
+    font-size: var(--fs-14);
+  }
 
 /* Liikettä vähentäville käyttäjille: poista siirtymät/siirrot */
 @media (prefers-reduced-motion: reduce) {

--- a/app/styles/tokens.css
+++ b/app/styles/tokens.css
@@ -22,7 +22,9 @@
   --fs-14: 0.875rem;
   --fs-16: 1rem;
   --fs-20: 1.25rem;
+  --fs-24: 1.5rem;
   --fs-28: 1.75rem;
+  --fs-32: 2rem;
   --lh-tight: 1.4;
   --lh-relaxed: 1.6;
 

--- a/app/visual_analytics.py
+++ b/app/visual_analytics.py
@@ -53,7 +53,7 @@ def tag_style():
         <style>
         .tag-button { background-color: #ff4d4d; color: white; border-radius: 1rem;
             padding: 0.4rem 0.8rem; margin: 0.2rem; display: inline-block;
-            font-weight: bold; font-size: 0.9rem; }
+            font-weight: bold; font-size: var(--fs-14); }
         </style>
         """, unsafe_allow_html=True
     )


### PR DESCRIPTION
## Summary
- add fs-24 and fs-32 tokens and map headings to a consistent scale
- enlarge KPI value styles and migrate inline components to shared tokens
- unify login form and sidebar text sizing via tokenized font-scale

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c4e92b1ef883209a5b870b51dd022d