### PR TITLE
Add highlight styles for standout metrics

### DIFF
--- a/app/inspect_player.py
+++ b/app/inspect_player.py
@@ -194,8 +194,23 @@ def show_inspect_player() -> None:
     ]
     df = df[[c for c in cols_order if c in df.columns]].sort_values("Date", ascending=False)
 
+    def _highlight_class(v: float | None) -> str:
+        if pd.isna(v):
+            return ""
+        if v >= 4:
+            return "sl-highlight"
+        if v <= 2:
+            return "sl-highlight-error"
+        return "sl-highlight-warning"
+
+    classes = pd.DataFrame("", index=df.index, columns=df.columns)
+    for col in ["Tech", "GI", "MENT", "ATH"]:
+        if col in classes.columns:
+            classes[col] = df[col].apply(_highlight_class)
+    styler = df.style.set_td_classes(classes)
+
     st.caption(f"Reports: **{len(df)}**")
-    st.dataframe(df, use_container_width=True)
+    st.dataframe(styler, use_container_width=True)
 
     csv_bytes = df.to_csv(index=False).encode("utf-8")
     json_bytes = df.to_json(orient="records", date_format="iso").encode("utf-8")

--- a/app/reports_page.py
+++ b/app/reports_page.py
@@ -290,27 +290,23 @@ def show_reports_page() -> None:
 
         if "Foot" in df_f.columns:
             df_f["Foot"] = df_f["Foot"].fillna("").astype(str).str.capitalize()
+        def _highlight_class(v: float | None) -> str:
+            if pd.isna(v):
+                return ""
+            if v >= 4:
+                return "sl-highlight"
+            if v <= 2:
+                return "sl-highlight-error"
+            return "sl-highlight-warning"
 
-        def _style_vals(s: pd.Series) -> list[str]:
-            colors: list[str] = []
-            for v in s:
-                if pd.isna(v):
-                    colors.append("")
-                elif isinstance(v, (int, float)):
-                    if v >= 4:
-                        colors.append("background-color: rgba(0, 200, 120, 0.15)")
-                    elif v <= 2:
-                        colors.append("background-color: rgba(255, 80, 80, 0.15)")
-                    else:
-                        colors.append("")
-                else:
-                    colors.append("")
-            return colors
+        classes = pd.DataFrame("", index=df_f.index, columns=df_f.columns)
+        for col in ["Tech", "GI", "MENT", "ATH"]:
+            if col in classes.columns:
+                classes[col] = df_f[col].apply(_highlight_class)
 
         with track("reports:style"):
             styler = (
-                df_f.style
-                .apply(_style_vals, subset=["Tech", "GI", "MENT", "ATH"])
+                df_f.style.set_td_classes(classes)
                 .set_properties(subset=["Comments"], **{"text-align": "left", "white-space": "pre-wrap"})
             )
 

--- a/app/styles/components.css
+++ b/app/styles/components.css
@@ -99,3 +99,27 @@
   border-color:var(--accent-1);
   box-shadow:0 0 0 1px var(--accent-1);
 }
+
+/* Highlights */
+.sl-highlight,
+.sl-highlight-warning,
+.sl-highlight-error {
+  padding: var(--space-1) var(--space-2);
+  border-left:4px solid;
+  border-radius:var(--radius-sm);
+}
+
+.sl-highlight {
+  border-color:var(--accent-cyan);
+  background:color-mix(in srgb, var(--accent-cyan) 20%, transparent);
+}
+
+.sl-highlight-warning {
+  border-color:var(--warning);
+  background:color-mix(in srgb, var(--warning) 20%, transparent);
+}
+
+.sl-highlight-error {
+  border-color:var(--error);
+  background:color-mix(in srgb, var(--error) 20%, transparent);
+}


### PR DESCRIPTION
## Summary
- add generic `.sl-highlight` style and variants for warnings/errors
- highlight report metrics using these styles in match report listings
- highlight player report metrics on Inspect Player page

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c4e92e8cf083208aaa4a057e738cb5