### PR TITLE
codex: add primary and secondary button styles

### DIFF
--- a/app/add_player_form.py
+++ b/app/add_player_form.py
@@ -190,9 +190,9 @@ def show_add_player_form():
 
         left, right = st.columns([1,1])
         with left:
-            save_btn = st.form_submit_button("💾 Tallenna pelaaja", use_container_width=True)
+            save_btn = st.form_submit_button("💾 Tallenna pelaaja", use_container_width=True, type="primary")
         with right:
-            save_add_btn = st.form_submit_button("💾 Tallenna ja lisää seuraava", use_container_width=True)
+            save_add_btn = st.form_submit_button("💾 Tallenna ja lisää seuraava", use_container_width=True, type="primary")
 
         # ---------------------------
         # Validation & Save

--- a/app/age_minutes.py
+++ b/app/age_minutes.py
@@ -11,7 +11,7 @@ def show_age_minutes():
 
     if selected_team == "Create new team...":
         new_team = st.sidebar.text_input("New team name")
-        if st.sidebar.button("Create Team"):
+        if st.sidebar.button("Create Team", type="primary"):
             if new_team.strip():
                 selected_team = new_team.strip()
                 st.session_state["selected_team"] = selected_team
@@ -40,7 +40,7 @@ def show_age_minutes():
         loan = st.checkbox("On Loan")
         minutes = st.number_input("Minutes Played", min_value=0)
         matches = st.number_input("Matches Played", min_value=0)
-        submitted = st.form_submit_button("Add / Update Player")
+        submitted = st.form_submit_button("Add / Update Player", type="primary")
 
         if submitted:
             is_valid, msg = validate_player_input(name, df)
@@ -66,7 +66,7 @@ def show_age_minutes():
     df_sorted = df.sort_values("Name")
     st.sidebar.header("Remove Player")
     remove_name = st.sidebar.selectbox("Select player to remove", options=["-"] + df_sorted["Name"].tolist())
-    if st.sidebar.button("Remove") and remove_name != "-":
+    if st.sidebar.button("Remove", type="secondary") and remove_name != "-":
         df = df[df["Name"] != remove_name]
         save_data(df, team_name)
         st.sidebar.success(f"Removed player: {remove_name}")

--- a/app/app.py
+++ b/app/app.py
@@ -121,7 +121,7 @@ def main() -> None:
                 f"<div class='sb-user'>Signed in as {name}</div>",
                 unsafe_allow_html=True,
             )
-            st.button("Sign out", on_click=logout)
+            st.button("Sign out", on_click=logout, type="secondary")
 
         st.markdown(
             f"<div class='sb-footer'><strong>{APP_TITLE}</strong> v{APP_VERSION}</div>",

--- a/app/calendar_ui.py
+++ b/app/calendar_ui.py
@@ -186,9 +186,9 @@ def _form(default: Optional[Dict[str, Any]] = None) -> Optional[Dict[str, Any]]:
 
     c1, c2 = st.columns(2)
     with c1:
-        save = st.button("Save", use_container_width=True)
+        save = st.button("Save", use_container_width=True, type="primary")
     with c2:
-        cancel = st.button("Cancel", use_container_width=True)
+        cancel = st.button("Cancel", use_container_width=True, type="secondary")
 
     if cancel:
         st.session_state[K_MODE] = None
@@ -294,12 +294,12 @@ def _card(m: Dict[str, Any], tz: str):
 
     c1, c2, _ = st.columns([1, 1, 2])
     with c1:
-        if st.button(f"Edit {m['id']}", key=f"edit_{m['id']}", use_container_width=True):
+        if st.button(f"Edit {m['id']}", key=f"edit_{m['id']}", use_container_width=True, type="primary"):
             st.session_state[K_MODE] = "edit"
             st.session_state[K_EDIT] = m["id"]
             st.rerun()
     with c2:
-        if st.button(f"Delete {m['id']}", key=f"del_{m['id']}", use_container_width=True):
+        if st.button(f"Delete {m['id']}", key=f"del_{m['id']}", use_container_width=True, type="secondary"):
             _delete(m["id"])
             st.success("Deleted.")
             st.rerun()
@@ -310,11 +310,11 @@ def show_calendar():
 
     t1, t2, t3 = st.columns([0.3, 0.3, 0.4])
     with t1:
-        if st.button("↻ Reload", help="Clear cache and reload", use_container_width=True):
+        if st.button("↻ Reload", help="Clear cache and reload", use_container_width=True, type="secondary"):
             _bust()
             st.rerun()
     with t2:
-        if st.button("➕ Add match", use_container_width=True):
+        if st.button("➕ Add match", use_container_width=True, type="primary"):
             st.session_state[K_MODE] = "add"
             st.session_state[K_EDIT] = None
     with t3:

--- a/app/data_manager.py
+++ b/app/data_manager.py
@@ -135,7 +135,7 @@ def show_data_manager():
         return
 
     # 3) Tallenna muutokset players.jsoniin (korvaa valitun joukkueen rivit)
-    if st.button("Save Changes", key="dm_save_players"):
+    if st.button("Save Changes", key="dm_save_players", type="primary"):
         try:
             kept = [p for p in players_all if _norm_team(p) != team]
             new_rows = []

--- a/app/home.py
+++ b/app/home.py
@@ -240,7 +240,7 @@ def show_home():
             placeholder="Observations, ideas, follow-ups…",
             height=100,
         )
-        if st.button("Save note", use_container_width=True):
+        if st.button("Save note", use_container_width=True, type="primary"):
             _append_note(text)
             st.success("Saved.")
             st.cache_data.clear()  # nollaa _load_notes cache

--- a/app/lineup_planner.py
+++ b/app/lineup_planner.py
@@ -131,7 +131,7 @@ def show_lineup_planner():
     with st.form("add_form", clear_on_submit=True):
         pos = st.selectbox("Position", available_positions)
         player = st.selectbox("Player", available_players)
-        if st.form_submit_button("Add to Lineup"):
+        if st.form_submit_button("Add to Lineup", type="primary"):
             st.session_state.lineup[pos] = player
             save_lineup(st.session_state.lineup, session_key)
             st.success(f"Added {player} at {pos}")
@@ -140,12 +140,12 @@ def show_lineup_planner():
     lineup_df = pd.DataFrame.from_dict(st.session_state.lineup, orient='index', columns=['Player'])
     st.table(lineup_df)
 
-    if st.button("Visualize on Pitch"):
+    if st.button("Visualize on Pitch", type="primary"):
         fig = draw_lineup(st.session_state.lineup)
         if fig:
             st.pyplot(fig)
 
-    if st.button("Clear Lineup"):
+    if st.button("Clear Lineup", type="secondary"):
         st.session_state.lineup = {}
         save_lineup({}, session_key)
         st.success("Lineup cleared.")

--- a/app/login.py
+++ b/app/login.py
@@ -234,7 +234,7 @@ def login(
         username = st.text_input("Username", autocomplete="username", placeholder="Enter your username")
         password = st.text_input("Password", type="password", autocomplete="current-password", placeholder="Enter your password")
         remember = st.checkbox("Keep me signed in (this session)", value=True)
-        submitted = st.form_submit_button("Sign in")
+        submitted = st.form_submit_button("Sign in", type="primary")
 
     if submitted:
         if len(password) < cfg.min_password_len:

--- a/app/notes.py
+++ b/app/notes.py
@@ -102,7 +102,7 @@ def show_notes():
 
     cc1, cc2, cc3 = st.columns([1,1,2.2])
     with cc1:
-        if st.button("💾 Save note", key="notes__save"):
+        if st.button("💾 Save note", key="notes__save", type="primary"):
             t = (text or "").strip()
             tags = _clean_tags(tags_str or "")
             if t:
@@ -115,7 +115,7 @@ def show_notes():
             else:
                 st.warning("Write something first.")
     with cc2:
-        if st.button("✖️ Clear", key="notes__clear"):
+        if st.button("✖️ Clear", key="notes__clear", type="secondary"):
             st.session_state["notes__new_text"] = ""
             st.session_state["notes__new_tags"] = ""
 
@@ -138,7 +138,7 @@ def show_notes():
     with b3:
         sort_order = st.selectbox("Sort", ["Newest first", "Oldest first"], key="notes__sort")
     with b4:
-        if st.button("Reset filters", key="notes__reset"):
+        if st.button("Reset filters", key="notes__reset", type="secondary"):
             st.session_state["notes__q"] = ""
             st.session_state["notes__tags"] = []
             st.session_state["notes__sort"] = "Newest first"
@@ -196,7 +196,12 @@ def show_notes():
         picks = st.multiselect("Select notes to delete", options=ids, format_func=lambda nid: next((f"{_fmt_ts(n['created_at'])}  •  {(n['text'][:40] + '…' if len(n['text'])>40 else n['text'])}" for n in page_items if n['id']==nid), nid), key="notes__bulk")
         st.warning("Type DELETE to confirm bulk deletion.", icon="⚠️")
         confirm = st.text_input("Confirmation", key="notes__confirm", placeholder="DELETE")
-        if st.button(f"🗑️ Delete selected ({len(picks)})", disabled=(len(picks)==0 or confirm!="DELETE"), key="notes__bulk_del"):
+        if st.button(
+            f"🗑️ Delete selected ({len(picks)})",
+            disabled=(len(picks)==0 or confirm!="DELETE"),
+            key="notes__bulk_del",
+            type="secondary",
+        ):
             kept = [n for n in notes if n.get("id") not in set(picks)]
             _save_notes(kept)
             st.cache_data.clear()
@@ -219,7 +224,7 @@ def show_notes():
                     if tg:
                         st.caption(" ".join(f"`{t}`" for t in tg))
                 with top[2]:
-                    if st.button("🗑️ Delete", key=f"notes__del_{n['id']}"):
+                    if st.button("🗑️ Delete", key=f"notes__del_{n['id']}", type="secondary"):
                         kept = [m for m in notes if m.get("id") != n["id"]]
                         _save_notes(kept)
                         st.cache_data.clear()
@@ -233,7 +238,7 @@ def show_notes():
                 with st.expander("✏️ Edit"):
                     new_text = st.text_area("Edit text", value=n.get("text",""), key=f"notes__edit_text_{n['id']}", height=120)
                     new_tags = st.text_input("Edit tags (comma-separated)", value=", ".join(n.get("tags",[])), key=f"notes__edit_tags_{n['id']}")
-                    if st.button("💾 Save changes", key=f"notes__edit_save_{n['id']}"):
+                    if st.button("💾 Save changes", key=f"notes__edit_save_{n['id']}", type="primary"):
                         n["text"] = (new_text or "").strip()
                         n["tags"] = _clean_tags(new_tags or "")
                         # write back (keep ordering)

--- a/app/player_editor.py
+++ b/app/player_editor.py
@@ -443,7 +443,7 @@ def _render_shortlist_flow():
     if not shortlists:
         st.info("Ei shortlisteja vielä. Luo listat Home/Team View -sivuilla tai luo uusi tässä.")
         new_name = st.text_input("Uuden shortlistin nimi", value="default", key="pe_new_shortlist_name")
-        if st.button("Luo shortlist"):
+        if st.button("Luo shortlist", type="primary"):
             if new_name.strip():
                 shortlists[new_name.strip()] = []
                 _save_shortlists(shortlists)
@@ -505,7 +505,7 @@ def _render_team_editor_flow(selected_team: str, preselected_name: Optional[str]
 
     # Lisää ensimmäinen rivi, jos rosteri on tyhjä
     if empty_state:
-        if st.button("➕ Create first player row", key=f"pe_first_row__{selected_team}"):
+        if st.button("➕ Create first player row", key=f"pe_first_row__{selected_team}", type="primary"):
             df_master = df_master.loc[:, ~df_master.columns.duplicated()]
             new_id = _new_player_id()
             new_row = {col: "" for col in df_master.columns}
@@ -525,7 +525,7 @@ def _render_team_editor_flow(selected_team: str, preselected_name: Optional[str]
             num_rows="dynamic",
             key=f"pe_full_editor__{selected_team}"
         )
-        if st.button("💾 Save table", key=f"pe_save_table__{selected_team}"):
+        if st.button("💾 Save table", key=f"pe_save_table__{selected_team}", type="primary"):
             df_master.loc[:, edit_cols] = table_edit.loc[:, edit_cols].values
 
             # numerot (except PlayerID)
@@ -548,7 +548,7 @@ def _render_team_editor_flow(selected_team: str, preselected_name: Optional[str]
 
     # Lisää uusi rivi -osio
     with st.expander("➕ Add New Player", expanded=False):
-        if st.button("Add row", key=f"pe_add_row__{selected_team}"):
+        if st.button("Add row", key=f"pe_add_row__{selected_team}", type="primary"):
             df_master = df_master.loc[:, ~df_master.columns.duplicated()]
             new_id = _new_player_id()
             new_row = {col: "" for col in df_master.columns}
@@ -637,7 +637,7 @@ def _render_team_editor_flow(selected_team: str, preselected_name: Optional[str]
         if problems:
             st.info(" | ".join(problems))
 
-        if st.button("💾 Save Basic Info", key=f"{selected_team}_{pid_str}_save_basic"):
+        if st.button("💾 Save Basic Info", key=f"{selected_team}_{pid_str}_save_basic", type="primary"):
             idxs = df_master[df_master["PlayerID"] == pid_str].index
             if not idxs.empty:
                 idx = idxs[0]
@@ -662,11 +662,12 @@ def _render_team_editor_flow(selected_team: str, preselected_name: Optional[str]
                 key=f"{pid_str}_nav_report",
                 on_click=go,
                 args=("Reports",),
+                type="primary",
             )
 
         st.markdown("---")
         st.markdown("### 📄 Save THIS player to storage")
-        if st.button("⬇️ Save THIS player", key=f"{selected_team}_{pid_str}_push_this"):
+        if st.button("⬇️ Save THIS player", key=f"{selected_team}_{pid_str}_push_this", type="primary"):
             player_data = {
                 "id": pid_str,
                 "name": _as_str(name_val),
@@ -718,7 +719,7 @@ def _render_team_editor_flow(selected_team: str, preselected_name: Optional[str]
         st.session_state[tags_key] = tag_str
         st.caption("Vinkki: muutama iskevä tagi (esim. 'Press-resistance, Pace, Leader').")
 
-        if st.button("💾 Save tags", key=f"{selected_team}_{pid_str}_save_tags"):
+        if st.button("💾 Save tags", key=f"{selected_team}_{pid_str}_save_tags", type="primary"):
             tags = [t.strip() for t in tag_str.split(",") if t.strip()]
             client = get_client()
             if client:
@@ -760,7 +761,7 @@ def _render_team_editor_flow(selected_team: str, preselected_name: Optional[str]
                         use_container_width=True,
                         key=f"{selected_team}_{pid_str}_stats_new"
                     )
-                    if st.button("💾 Create Season Stats", key=f"{selected_team}_{pid_str}_stats_create"):
+                    if st.button("💾 Create Season Stats", key=f"{selected_team}_{pid_str}_stats_create", type="primary"):
                         merged = pd.concat([stats_df, edited_stats], ignore_index=True)
                         save_seasonal_stats(merged, selected_team)
                         st.success("Season stats created.")
@@ -771,7 +772,7 @@ def _render_team_editor_flow(selected_team: str, preselected_name: Optional[str]
                         use_container_width=True,
                         key=f"{selected_team}_{pid_str}_stats_edit"
                     )
-                    if st.button("💾 Save Season Stats", key=f"{selected_team}_{pid_str}_stats_save"):
+                    if st.button("💾 Save Season Stats", key=f"{selected_team}_{pid_str}_stats_save", type="primary"):
                         mask = stats_df[name_col] == selected_name
                         stats_df.loc[mask, :] = edited_stats.values
                         save_seasonal_stats(stats_df, selected_team)
@@ -802,7 +803,7 @@ def _render_team_editor_flow(selected_team: str, preselected_name: Optional[str]
         st.subheader("🗑️ Actions")
         a1, a2, a3 = st.columns(3)
         with a1:
-            if st.button("Duplicate row", key=f"{selected_team}_{pid_str}_dup"):
+            if st.button("Duplicate row", key=f"{selected_team}_{pid_str}_dup", type="primary"):
                 copy = df_master[df_master["PlayerID"]==pid_str].iloc[0].copy()
                 copy["PlayerID"] = _new_player_id()
                 copy["Name"] = f"{copy.get('Name','')} (copy)"
@@ -812,7 +813,7 @@ def _render_team_editor_flow(selected_team: str, preselected_name: Optional[str]
                 st.success("Row duplicated.")
         with a2:
             new_team = st.selectbox("Move to team", options=[""] + list_teams(), index=0, key=f"{selected_team}_{pid_str}_move_team")
-            if new_team and st.button("Move now", key=f"{selected_team}_{pid_str}_move_now"):
+            if new_team and st.button("Move now", key=f"{selected_team}_{pid_str}_move_now", type="primary"):
                 if new_team == selected_team:
                     st.warning("Same team selected.")
                 else:
@@ -836,7 +837,7 @@ def _render_team_editor_flow(selected_team: str, preselected_name: Optional[str]
         with a3:
             st.warning("Type DELETE to confirm deletion from master file", icon="⚠️")
             conf = st.text_input("Confirmation", key=f"{selected_team}_{pid_str}_del_conf", placeholder="DELETE")
-            if st.button("Delete row from master", key=f"{selected_team}_{pid_str}_del_row", disabled=(conf != "DELETE")):
+            if st.button("Delete row from master", key=f"{selected_team}_{pid_str}_del_row", disabled=(conf != "DELETE"), type="secondary"):
                 df_master = df_master[df_master["PlayerID"] != pid_str]
                 _save_master_sanitized(df_master, selected_team)
                 st.cache_data.clear()
@@ -846,13 +847,13 @@ def _render_team_editor_flow(selected_team: str, preselected_name: Optional[str]
         st.subheader("Remove from storage")
         st.caption("Siivoa taustavarastoa sotkematta master-tiedostoa.")
         conf2 = st.text_input("Type REMOVE to confirm", key=f"{selected_team}_{pid_str}_del_store_conf", placeholder="REMOVE")
-        if st.button("Remove by PlayerID", key=f"{selected_team}_{pid_str}_del_store_byid", disabled=(conf2 != "REMOVE")):
+        if st.button("Remove by PlayerID", key=f"{selected_team}_{pid_str}_del_store_byid", disabled=(conf2 != "REMOVE"), type="secondary"):
             n = remove_from_players_storage_by_ids([str(pid_str)])
             if n:
                 clear_players_cache()
             st.success(f"Removed {n} record(s) by id.")
 
-        if st.button("Remove by (name, team) pair", key=f"{selected_team}_{pid_str}_del_store_bykey", disabled=(conf2 != "REMOVE")):
+        if st.button("Remove by (name, team) pair", key=f"{selected_team}_{pid_str}_del_store_bykey", disabled=(conf2 != "REMOVE"), type="secondary"):
             nm = selected_name.strip(); tm = _as_str(selected_team)
             ids = []
             client = get_client()

--- a/app/reports_page.py
+++ b/app/reports_page.py
@@ -118,7 +118,7 @@ def render_add_player_form(on_success: Callable | None = None) -> None:
         current_club = st.text_input("Current Club", "")
         transfermarkt_url = st.text_input("Transfermarkt URL", "")
 
-        submitted = st.form_submit_button("Create Player", use_container_width=True)
+        submitted = st.form_submit_button("Create Player", use_container_width=True, type="primary")
         if submitted:
             if not name.strip():
                 st.error("Name is required.")
@@ -198,7 +198,7 @@ def show_reports_page() -> None:
 
             st.divider()
             attrs = render_essential_section()
-            submitted = st.form_submit_button("Save")
+            submitted = st.form_submit_button("Save", type="primary")
 
         if submitted:
             sb = get_client()
@@ -318,7 +318,7 @@ def show_reports_page() -> None:
         with cap_col:
             st.caption(f"Showing {len(df_f)} / {len(df)} reports")
         with btn_col:
-            if st.button("Clear filters", key="reports__clear_filters"):
+            if st.button("Clear filters", key="reports__clear_filters", type="secondary"):
                 st.session_state.update(
                     {"reports__f_opp": "", "reports__f_comp": "", "reports__f_ment": 1}
                 )

--- a/app/scout_reporter.py
+++ b/app/scout_reporter.py
@@ -324,7 +324,7 @@ def show_scout_match_reporter():
         )
         comp = st.text_input("Competition (optional)", key="scout_reporter__comp")
         loc = st.text_input("Location (optional)", key="scout_reporter__loc")
-        if st.button("Add Match", key="scout_reporter__add_match_btn"):
+        if st.button("Add Match", key="scout_reporter__add_match_btn", type="primary"):
             if home and away:
                 local_dt = datetime.combine(mdate, mtime).replace(tzinfo=ZoneInfo(latam_tz))
                 kickoff_at = local_dt.isoformat()
@@ -472,7 +472,7 @@ def show_scout_match_reporter():
                 st.write(general_text.strip())
     general = general_text
 
-    if st.button("💾 Save Report", key="scout_reporter__save_report_btn"):
+    if st.button("💾 Save Report", key="scout_reporter__save_report_btn", type="primary"):
         save_report([
             {
                 "id": uuid.uuid4().hex,
@@ -665,7 +665,8 @@ def show_scout_match_reporter():
         if st.button(
             f"Delete selected ({len(selected_ids)})",
             disabled=(len(selected_ids) == 0 or confirm != "DELETE"),
-            key="scout_reporter__del_selected_btn"
+            key="scout_reporter__del_selected_btn",
+            type="secondary",
         ):
             with st.spinner("Deleting selected..."):
                 delete_reports(selected_ids)
@@ -675,7 +676,8 @@ def show_scout_match_reporter():
         if st.button(
             f"Delete filtered ({len(filtered_ids)})",
             disabled=(len(filtered_ids) == 0 or confirm != "DELETE"),
-            key="scout_reporter__del_filtered_btn"
+            key="scout_reporter__del_filtered_btn",
+            type="secondary",
         ):
             with st.spinner("Deleting filtered..."):
                 delete_reports(filtered_ids)

--- a/app/shortlists.py
+++ b/app/shortlists.py
@@ -130,14 +130,14 @@ def show_shortlists():
         sel = st.selectbox("Select", list_names or ["—"], index=0 if list_names else 0, key="sl_sel_page")
         new_nm = st.text_input("New list name", placeholder="e.g. U23 Forwards")
         c1, c2 = st.columns([1, 1])
-        if c1.button("Create"):
+        if c1.button("Create", type="primary"):
             nn = new_nm.strip()
             if nn and nn not in shortlists:
                 shortlists[nn] = []
                 _save_shortlists(shortlists)
                 st.success(f"Created '{nn}'")
                 st.cache_data.clear(); st.rerun()
-        if sel in shortlists and c2.button("Delete"):
+        if sel in shortlists and c2.button("Delete", type="secondary"):
             shortlists.pop(sel, None)
             _save_shortlists(shortlists)
             st.warning(f"Deleted '{sel}'")
@@ -146,7 +146,7 @@ def show_shortlists():
         # rename
         if sel in shortlists:
             rn = st.text_input("Rename", value=sel, key="sl_rename")
-            if rn.strip() and rn.strip() != sel and st.button("Apply rename"):
+            if rn.strip() and rn.strip() != sel and st.button("Apply rename", type="primary"):
                 shortlists[rn.strip()] = shortlists.pop(sel)
                 _save_shortlists(shortlists)
                 st.success("Renamed")
@@ -170,7 +170,7 @@ def show_shortlists():
                 key=f"sl_add_multi_{sel}",
             )
             cadd, cclear = st.columns([1, 1])
-            if cadd.button("Add selected"):
+            if cadd.button("Add selected", type="primary"):
                 added = 0
                 for n in add:
                     pid = name_to_id.get(n)
@@ -181,7 +181,7 @@ def show_shortlists():
                     _save_shortlists(shortlists)
                     st.success(f"Added {added} players")
                     st.cache_data.clear(); st.rerun()
-            if cclear.button("Clear list"):
+            if cclear.button("Clear list", type="secondary"):
                 shortlists[sel] = []
                 _save_shortlists(shortlists)
                 st.warning("Cleared")
@@ -205,7 +205,7 @@ def show_shortlists():
                     if rc3.button("⬇️", key=f"dn_{sel}_{i}", help="Move down") and i < len(items) - 1:
                         items[i + 1], items[i] = items[i], items[i + 1]
                         _save_shortlists(shortlists); st.rerun()
-                    if rc4.button("Remove", key=f"rm_{sel}_{i}"):
+                    if rc4.button("Remove", key=f"rm_{sel}_{i}", type="secondary"):
                         items.pop(i); _save_shortlists(shortlists); st.rerun()
 
                 # export

--- a/app/shortlists_page.py
+++ b/app/shortlists_page.py
@@ -81,7 +81,7 @@ def show_shortlists_page() -> None:
     # create shortlist
     with st.expander("Create new shortlist"):
         name = st.text_input("Shortlist name", key="shortlists__name")
-        if st.button("Create"):
+        if st.button("Create", type="primary"):
             if not name.strip():
                 st.warning("Name required.")
             else:
@@ -126,7 +126,7 @@ def show_shortlists_page() -> None:
     add_pid = st.selectbox(
         "Player", options=list(label_by_id.keys()), format_func=lambda x: label_by_id[x], key="shortlists__add_pid"
     )
-    if st.button("Add to shortlist"):
+    if st.button("Add to shortlist", type="primary"):
         try:
             sb.table("shortlist_items").insert({"shortlist_id": sid, "player_id": add_pid}).execute()
             list_shortlist_items.clear()
@@ -155,7 +155,7 @@ def show_shortlists_page() -> None:
                 options=[p["id"] for p in plist],
                 format_func=lambda x: next(p["name"] for p in plist if p["id"] == x),
             )
-            if st.button("Remove"):
+            if st.button("Remove", type="secondary"):
                 sb.table("shortlist_items").delete().eq("shortlist_id", sid).eq("player_id", pid_to_remove).execute()
                 list_shortlist_items.clear()
                 list_players_by_ids.clear()

--- a/app/styles/components.css
+++ b/app/styles/components.css
@@ -4,7 +4,9 @@
 .sl-kpi .value { font-size: var(--fs-28); font-weight:700; }
 
 /* Buttons */
-.stButton>button, .sl-btn {
+.stButton>button:not([kind]),
+.stButton>button[kind="primary"],
+.sl-btn-primary {
   background: var(--accent-1);
   color: var(--fg-strong);
   border: none;
@@ -14,15 +16,42 @@
   transition: background .2s ease, box-shadow .2s ease, transform .2s ease;
   cursor: pointer;
 }
-.stButton>button:hover, .sl-btn:hover {
+.stButton>button:not([kind]):hover,
+.stButton>button[kind="primary"]:hover,
+.sl-btn-primary:hover {
   background: linear-gradient(90deg,var(--accent-1),var(--accent-2));
   transform: translateY(-1px);
   box-shadow: var(--shadow-hover);
 }
-.stButton>button:focus, .sl-btn:focus {
+.stButton>button:not([kind]):focus,
+.stButton>button[kind="primary"]:focus,
+.sl-btn-primary:focus {
   outline: 2px solid var(--accent-cyan);
   outline-offset:2px;
 }
+
+.stButton>button[kind="secondary"],
+.sl-btn-secondary {
+  background: var(--bg-card);
+  color: var(--accent-1);
+  border:1px solid var(--accent-1);
+  border-radius: var(--radius-md);
+  padding: var(--space-2) var(--space-3);
+  font-size: var(--fs-14);
+  transition: background .2s ease, box-shadow .2s ease;
+  cursor: pointer;
+}
+.stButton>button[kind="secondary"]:hover,
+.sl-btn-secondary:hover {
+  background: color-mix(in srgb, var(--accent-1) 15%, var(--bg-card));
+  box-shadow: var(--shadow-hover);
+}
+.stButton>button[kind="secondary"]:focus,
+.sl-btn-secondary:focus {
+  outline: 2px solid var(--accent-cyan);
+  outline-offset:2px;
+}
+
 .stButton>button:disabled {
   opacity:0.5;
   cursor:not-allowed;
@@ -31,7 +60,8 @@
 }
 
 /* Anchor buttons */
-.sl-btn {
+.sl-btn-primary,
+.sl-btn-secondary {
   display: inline-flex;
   align-items: center;
   gap: var(--space-1);


### PR DESCRIPTION
## Summary
- introduce `.sl-btn-primary` and `.sl-btn-secondary` classes with accent and neutral themes
- mark Streamlit buttons with primary/secondary types across pages
- keep primary actions vibrant and secondary actions subtle

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c4e92bfcc88320a8f90cec47a97f42