### PR TITLE
Remove rerun from navigation helper

### DIFF
--- a/app/ui/nav.py
+++ b/app/ui/nav.py
@@ -4,9 +4,8 @@ import streamlit as st
 
 
 def go(page: str) -> None:
-    """Switch to the given page and trigger a rerun."""
+    """Switch to the given page by updating session state."""
     st.session_state["current_page"] = page
-    st.rerun()
 
 
 __all__ = ["go"]


### PR DESCRIPTION
## Summary
- simplify page navigation by updating session state without rerun

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c4f16bd1948320a13b1373692b368b