### PR TITLE
codex: rely on button rerun for logout

### DIFF
--- a/app/login.py
+++ b/app/login.py
@@ -121,9 +121,9 @@ def _clear_failures() -> None:
 # ============================
 def logout() -> None:
     _ensure_auth_state()
-    st.session_state["auth"]["authenticated"] = False
-    st.session_state["auth"]["user"] = None
-    st.rerun()
+    auth = st.session_state["auth"]
+    auth["authenticated"] = False
+    auth["user"] = None
 
 def login(
     title: str = "ScoutLens",


### PR DESCRIPTION
## Summary
- remove explicit `st.rerun()` in `logout` and rely on button rerun

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c4f16cedfc8320abbd5907b626b5ed