### PR TITLE
codex: add player management and shortlist deletion

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -40,6 +40,7 @@ def _safe_import(what: str, mod: str, attr: str):
 show_reports_page   = _safe_import("reports page",   "app.reports_page",   "show_reports_page")
 show_inspect_player = _safe_import("inspect player", "app.inspect_player", "show_inspect_player")
 show_shortlists_page= _safe_import("shortlists",     "app.shortlists_page","show_shortlists_page")
+show_player_management_page = _safe_import("player management", "app.player_management", "show_player_management_page")
 show_export_page    = _safe_import("export",         "app.export_page",    "show_export_page")
 login               = _safe_import("login",          "app.login",          "login")
 logout              = _safe_import("logout",         "app.login",          "logout")
@@ -60,11 +61,12 @@ def inject_css():
         st.markdown(f"<style>{'\n'.join(parts)}</style>", unsafe_allow_html=True)
 
 # --------- Nav
-NAV_KEYS = ["Reports", "Inspect Player", "Shortlists", "Export"]
+NAV_KEYS = ["Reports", "Inspect Player", "Shortlists", "Players", "Export"]
 NAV_LABELS = {
     "Reports": "📝 Reports",
     "Inspect Player": "🔍 Inspect Player",
     "Shortlists": "⭐ Shortlists",
+    "Players": "👤 Players",
     "Export": "⬇️ Export",
 }
 LEGACY_REMAP = {
@@ -78,6 +80,7 @@ PAGE_FUNCS = {
     "Reports": show_reports_page,
     "Inspect Player": show_inspect_player,
     "Shortlists": show_shortlists_page,
+    "Players": show_player_management_page,
     "Export": show_export_page,
 }
 

--- a/app/player_management.py
+++ b/app/player_management.py
@@ -1,0 +1,69 @@
+"""Player management page allowing deletion of players."""
+
+from __future__ import annotations
+
+import streamlit as st
+from postgrest.exceptions import APIError
+
+from app.ui import bootstrap_sidebar_auto_collapse
+from app.supabase_client import get_client
+from app.player_editor import remove_from_players_storage_by_ids
+
+
+@st.cache_data(ttl=60, show_spinner=False)
+def list_players():
+    sb = get_client()
+    return (
+        sb.table("players")
+        .select("id,name,position,current_club")
+        .order("name")
+        .execute()
+        .data
+        or []
+    )
+
+
+bootstrap_sidebar_auto_collapse()
+
+
+def show_player_management_page() -> None:
+    st.title("👤 Players")
+
+    auth = st.session_state.get("auth", {})
+    if not auth.get("authenticated"):
+        st.info("Sign in to delete players.")
+        return
+
+    try:
+        players = list_players()
+    except APIError as e:  # pragma: no cover - UI error handling
+        st.error(f"Failed to load players: {e}")
+        return
+
+    if not players:
+        st.info("No players available.")
+        return
+
+    label_by_id = {
+        p["id"]: f"{p['name']} – {p.get('position') or '—'} ({p.get('current_club') or '—'})"
+        for p in players
+    }
+    selected_ids = st.multiselect(
+        "Players to delete",
+        options=list(label_by_id.keys()),
+        format_func=lambda x: label_by_id[x],
+        key="player_mgmt__ids",
+    )
+
+    if st.button("Delete selected", type="secondary", disabled=not selected_ids):
+        try:
+            remove_from_players_storage_by_ids(selected_ids)
+            list_players.clear()
+            st.success("Deleted selected players.")
+            st.rerun()
+        except Exception as e:  # pragma: no cover - UI error handling
+            st.error(f"Failed to delete players: {e}")
+
+
+__all__ = ["show_player_management_page"]
+

--- a/app/shortlists_page.py
+++ b/app/shortlists_page.py
@@ -111,6 +111,17 @@ def show_shortlists_page() -> None:
     )
     st.session_state["shortlists__sid"] = sid
 
+    if st.button("Delete shortlist", type="secondary"):
+        try:
+            sb.table("shortlist_items").delete().eq("shortlist_id", sid).execute()
+            sb.table("shortlists").delete().eq("id", sid).execute()
+            list_shortlists.clear()
+            list_shortlist_items.clear()
+            st.toast("Shortlist deleted ✅")
+            st.rerun()
+        except APIError as e:  # pragma: no cover - UI error handling
+            st.error(f"Failed to delete shortlist: {e}")
+
     # add players
     st.subheader("Add players")
     try:


### PR DESCRIPTION
## Summary
- allow removing entire shortlist from Shortlists page
- add Players page to delete multiple players
- wire Players page into navigation

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c4ff3d4620832089004c898b624488