### PR TITLE
Add logo to sidebar

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -141,6 +141,7 @@ def main() -> None:
     current = st.session_state.get("current_page", NAV_KEYS[0])
 
     with st.sidebar:
+        st.sidebar.image(str(ROOT / "assets" / "logo.png"), use_container_width=True)
         st.markdown("<div class='scout-brand'>⚽ ScoutLens</div>", unsafe_allow_html=True)
         st.markdown(f"<div class='scout-sub'>{APP_TAGLINE}</div>", unsafe_allow_html=True)
         st.markdown("<div class='nav-sep'>Navigation</div>", unsafe_allow_html=True)

--- a/app/styles/sidebar.css
+++ b/app/styles/sidebar.css
@@ -10,6 +10,10 @@ section[data-testid="stSidebar"] {
 section[data-testid="stSidebar"] .block-container {
   padding: var(--space-5) var(--space-4);
 }
+section[data-testid="stSidebar"] .block-container img {
+  width: 100%;
+  margin-bottom: var(--space-4);
+}
 
 section[data-testid="stSidebar"] [role="radiogroup"] > label {
   border: 1px solid var(--divider);


### PR DESCRIPTION
## Summary
- display logo at top of sidebar
- style sidebar image with full width and spacing

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c672a1c10483208f2a111c864bd3c7