### PR TITLE
codex: refine sidebar UX

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -37,6 +37,9 @@ bootstrap_sidebar_auto_collapse = importlib.import_module("app.ui").__getattribu
 set_sidebar_background = importlib.import_module("app.ui.sidebar_bg").__getattribute__(
     "set_sidebar_background"
 )
+build_sidebar = importlib.import_module("app.ui.sidebar").__getattribute__(
+    "build_sidebar"
+)
 
 st.set_page_config(page_title="ScoutLens", layout="wide", initial_sidebar_state="expanded")
 
@@ -140,36 +143,16 @@ def main() -> None:
 
     current = st.session_state.get("current_page", NAV_KEYS[0])
 
-    with st.sidebar:
-        st.sidebar.image(str(ROOT / "assets" / "logo.png"), use_container_width=True)
-        st.markdown("<div class='scout-brand'>⚽ ScoutLens</div>", unsafe_allow_html=True)
-        st.markdown(f"<div class='scout-sub'>{APP_TAGLINE}</div>", unsafe_allow_html=True)
-        st.markdown("<div class='nav-sep'>Navigation</div>", unsafe_allow_html=True)
-
-        st.radio(
-            "Navigate",
-            options=NAV_KEYS,
-            index=NAV_KEYS.index(current),
-            format_func=lambda k: NAV_LABELS.get(k, k),
-            key="_nav_radio",
-            label_visibility="collapsed",
-            on_change=lambda: go(st.session_state["_nav_radio"]),
-        )
-
-        auth = st.session_state.get("auth", {})
-        user = auth.get("user")
-        if auth.get("authenticated") and user:
-            name = user.get("name") or user.get("username", "")
-            st.markdown(
-                f"<div class='sb-user'>Signed in as {name}</div>",
-                unsafe_allow_html=True,
-            )
-            st.button("Sign out", on_click=logout, type="secondary")
-
-        st.markdown(
-            f"<div class='sb-footer'><strong>{APP_TITLE}</strong> v{APP_VERSION}</div>",
-            unsafe_allow_html=True,
-        )
+    build_sidebar(
+        current=current,
+        nav_keys=NAV_KEYS,
+        nav_labels=NAV_LABELS,
+        app_title=APP_TITLE,
+        app_tagline=APP_TAGLINE,
+        app_version=APP_VERSION,
+        go=go,
+        logout=logout,
+    )
 
     page_func = PAGE_FUNCS.get(current, lambda: st.error("Page not found."))
     with track(f"page:{current}"):

--- a/app/styles/sidebar.css
+++ b/app/styles/sidebar.css
@@ -7,6 +7,26 @@ section[data-testid="stSidebar"] {
   box-shadow: inset -1px 0 0 var(--divider);
 }
 
+section[data-testid="stSidebar"][aria-expanded="true"] {
+  min-width: 300px;
+  max-width: 300px;
+}
+
+section[data-testid="stSidebar"][aria-expanded="true"] > div:first-child {
+  min-width: 300px;
+  max-width: 300px;
+}
+
+section[data-testid="stSidebar"][aria-expanded="false"],
+section[data-testid="stSidebar"][aria-expanded="false"] > div:first-child {
+  min-width: 0;
+  max-width: 0;
+}
+
+[data-testid="stSidebarResizer"] {
+  display: none;
+}
+
 section[data-testid="stSidebar"] .block-container {
   padding: var(--space-5) var(--space-4);
 }

--- a/app/ui/sidebar.py
+++ b/app/ui/sidebar.py
@@ -1,10 +1,84 @@
-"""Placeholder sidebar helpers."""
+"""Sidebar utilities and builders."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Callable, Dict, Iterable
+
+import streamlit as st
 
 
 def bootstrap_sidebar_auto_collapse() -> None:
-    """Optional sidebar bootstrap stub."""
-    return
+    """Collapse the sidebar automatically on narrow viewports."""
+    st.markdown(
+        """
+        <script>
+        (function() {
+          const collapseBtn = window.parent.document.querySelector(
+            '[data-testid="stSidebarCollapseButton"]'
+          );
+          function autoCollapse() {
+            if (window.innerWidth < 768 && collapseBtn) {
+              collapseBtn.click();
+            }
+          }
+          window.addEventListener('load', autoCollapse);
+          window.addEventListener('resize', autoCollapse);
+        })();
+        </script>
+        """,
+        unsafe_allow_html=True,
+    )
 
 
-__all__ = ["bootstrap_sidebar_auto_collapse"]
+def build_sidebar(
+    *,
+    current: str,
+    nav_keys: Iterable[str],
+    nav_labels: Dict[str, str],
+    app_title: str,
+    app_tagline: str,
+    app_version: str,
+    go: Callable[[str], None],
+    logout: Callable[[], None],
+) -> None:
+    """Render the application sidebar."""
+
+    root = Path(__file__).resolve().parents[2]
+
+    with st.sidebar:
+        st.sidebar.image(str(root / "assets" / "logo.png"), use_container_width=True)
+        st.markdown("<div class='scout-brand'>⚽ ScoutLens</div>", unsafe_allow_html=True)
+        st.markdown(
+            f"<div class='scout-sub'>{app_tagline}</div>", unsafe_allow_html=True
+        )
+        st.markdown("<div class='nav-sep'>Navigation</div>", unsafe_allow_html=True)
+
+        st.radio(
+            "Navigate",
+            options=list(nav_keys),
+            index=list(nav_keys).index(current),
+            format_func=lambda k: nav_labels.get(k, k),
+            key="_nav_radio",
+            label_visibility="collapsed",
+            on_change=lambda: go(st.session_state["_nav_radio"]),
+        )
+
+        auth = st.session_state.get("auth", {})
+        user = auth.get("user")
+        if auth.get("authenticated") and user:
+            name = user.get("name") or user.get("username", "")
+            st.markdown(
+                f"<div class='sb-user'>Signed in as {name}</div>",
+                unsafe_allow_html=True,
+            )
+            st.button("Sign out", on_click=logout, type="secondary")
+
+        st.markdown(
+            f"<div class='sb-footer'><strong>{app_title}</strong> v{app_version}</div>",
+            unsafe_allow_html=True,
+        )
+
+
+__all__ = ["bootstrap_sidebar_auto_collapse", "build_sidebar"]
 


### PR DESCRIPTION
## Summary
- lock sidebar width and hide resizer
- auto-collapse sidebar on narrow viewports
- extract sidebar builder for cleaner main
- collapse sidebar to zero width so content expands fully

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c6778a414483208d6d79277ce97b5f