### PR TITLE
codex: add sidebar theme selection

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -84,8 +84,10 @@ APP_VERSION = "0.9.1"
 
 def inject_css():
     styles_dir = ROOT / "app" / "styles"
+    theme = st.session_state.get("theme", "dark")
+    token_file = f"tokens_{theme}.css"
     parts = []
-    for name in ["tokens.css", "layout.css", "components.css", "sidebar.css", "animations.css"]:
+    for name in [token_file, "layout.css", "components.css", "sidebar.css", "animations.css"]:
         p = styles_dir / name
         if p.exists():
             parts.append(p.read_text(encoding="utf-8"))
@@ -132,6 +134,9 @@ def main() -> None:
     except Exception:
         pass
 
+    if "theme" not in st.session_state:
+        st.session_state["theme"] = "dark"
+
     inject_css()
     set_sidebar_background()
     login()
@@ -152,6 +157,7 @@ def main() -> None:
         app_version=APP_VERSION,
         go=go,
         logout=logout,
+        inject_css=inject_css,
     )
 
     page_func = PAGE_FUNCS.get(current, lambda: st.error("Page not found."))

--- a/app/styles/tokens_dark.css
+++ b/app/styles/tokens_dark.css
@@ -1,4 +1,4 @@
-/* File: styles/tokens.css */
+/* File: styles/tokens_dark.css */
 :root {
   /* Colors – tuned to /mnt/data/login_bg.png (sunset, warm amber + deep brown) */
   --bg-page: #241700;     /* tummin ruskea tausta -> maksimi kontrasti */

--- a/app/styles/tokens_light.css
+++ b/app/styles/tokens_light.css
@@ -1,0 +1,49 @@
+/* File: styles/tokens_light.css */
+:root {
+  /* Light theme colors */
+  --bg-page: #FEF4DD;
+  --bg-card: #FFFFFF;
+  --accent-1: #A85A00;
+  --accent-2: #823D00;
+  --fg-strong: #241700;
+  --fg-muted: #5B2F00;
+  --accent-cyan: #3EA8B3;
+  --warning: #F59E0B;
+  --error: #DA3C2B;
+  --divider: rgba(36, 23, 0, 0.12);
+
+  /* Typography */
+  --font-sans: 'Inter', sans-serif;
+  --font-mono: 'JetBrains Mono', monospace;
+  --fs-12: 0.75rem;
+  --fs-14: 0.875rem;
+  --fs-16: 1rem;
+  --fs-20: 1.25rem;
+  --fs-24: 1.5rem;
+  --fs-28: 1.75rem;
+  --fs-32: 2rem;
+  --lh-tight: 1.4;
+  --lh-relaxed: 1.6;
+
+  /* Spacing */
+  --space-1: 4px;
+  --space-2: 8px;
+  --space-3: 12px;
+  --space-4: 16px;
+  --space-5: 24px;
+  --space-6: 32px;
+
+  /* Radius */
+  --radius-lg: 16px;
+  --radius-md: 14px;
+  --radius-sm: 6px;
+
+  /* Shadows */
+  --shadow-card: 0 4px 16px rgba(0, 0, 0, 0.15);
+  --shadow-hover: 0 6px 20px rgba(0, 0, 0, 0.25);
+}
+
+/* Optional: gradient helper for hero overlays */
+:root {
+  --overlay-sunset: linear-gradient(180deg, rgba(254, 244, 221, 0.7) 0%, rgba(254, 244, 221, 0.55) 35%, rgba(254, 244, 221, 0.3) 100%);
+}

--- a/app/ui/sidebar.py
+++ b/app/ui/sidebar.py
@@ -41,6 +41,7 @@ def build_sidebar(
     app_version: str,
     go: Callable[[str], None],
     logout: Callable[[], None],
+    inject_css: Callable[[], None] | None = None,
 ) -> None:
     """Render the application sidebar."""
 
@@ -62,6 +63,16 @@ def build_sidebar(
             key="_nav_radio",
             label_visibility="collapsed",
             on_change=lambda: go(st.session_state["_nav_radio"]),
+        )
+
+        theme_options = ["dark", "light"]
+        current_theme = st.session_state.get("theme", "dark")
+        st.selectbox(
+            "Theme",
+            options=theme_options,
+            index=theme_options.index(current_theme),
+            key="theme",
+            on_change=inject_css,
         )
 
         auth = st.session_state.get("auth", {})


### PR DESCRIPTION
## Summary
- add light and dark CSS token files and switch between them
- allow choosing theme in sidebar with session state
- inject selected theme's tokens along with layout styles

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c67cd7f830832083dbcef37d5e0463