### PR TITLE
codex: add fg-on-accent token

### DIFF
--- a/app/styles/components.css
+++ b/app/styles/components.css
@@ -8,7 +8,7 @@
 .stButton>button[kind="primary"],
 .sl-btn-primary {
   background: var(--accent-1);
-  color: var(--fg-strong);
+  color: var(--fg-on-accent);
   border: none;
   border-radius: var(--radius-md);
   padding: var(--space-2) var(--space-3);

--- a/app/styles/tokens_dark.css
+++ b/app/styles/tokens_dark.css
@@ -9,6 +9,7 @@
 
   --fg-strong: #FEF4DD;   /* lämmin kerma; teksti/ikonit, hyvä AA dark‑taustaa vasten */
   --fg-muted: #E0D2BE;    /* vaimennettu beige, toissijainen teksti */
+  --fg-on-accent: #241700; /* tumma teksti meripihkataustalla */
 
   --accent-cyan: #3EA8B3; /* viileä, desaturoitu teal vastapariksi lämpimälle paletille */
   --warning: #F59E0B;     /* lämmin varoitus */

--- a/app/styles/tokens_light.css
+++ b/app/styles/tokens_light.css
@@ -7,6 +7,7 @@
   --accent-2: #823D00;
   --fg-strong: #241700;
   --fg-muted: #5B2F00;
+  --fg-on-accent: #FEF4DD;
   --accent-cyan: #3EA8B3;
   --warning: #F59E0B;
   --error: #DA3C2B;


### PR DESCRIPTION
## Summary
- define `--fg-on-accent` for light and dark themes
- reference `--fg-on-accent` for primary button text

## Testing
- `pytest -q`
- `streamlit run app/app.py` *(fails: Did not auto detect external IP)*

------
https://chatgpt.com/codex/tasks/task_e_68c680f3c42c8320a6151730c1844185