### PR TITLE
codex: add theme tokens for skeleton and table striping

### DIFF
--- a/app/styles/animations.css
+++ b/app/styles/animations.css
@@ -9,7 +9,7 @@
 .skeleton { position:relative; overflow:hidden; background:var(--bg-card); }
 .skeleton::after {
   content:""; position:absolute; inset:0;
-  background:linear-gradient(90deg,transparent,rgba(255,255,255,0.05),transparent);
+  background:linear-gradient(90deg,transparent,var(--skeleton-highlight),transparent);
   animation: shimmer 1.2s infinite;
 }
 @keyframes shimmer { from{transform:translateX(-100%);} to{transform:translateX(100%);} }

--- a/app/styles/components.css
+++ b/app/styles/components.css
@@ -87,14 +87,14 @@
 }
 
 /* Table wrapper */
-.sl-table .stDataFrame, .sl-table .stTable {
-  border:1px solid var(--divider);
-  border-radius:var(--radius-md);
-  overflow:hidden;
-}
-.sl-table thead tr { position:sticky; top:0; background:var(--bg-card); }
-.sl-table tbody tr:nth-child(even){ background:rgba(255,255,255,0.02); }
-.sl-table tbody tr:hover{ background:color-mix(in srgb, var(--accent-1) 10%, transparent); }
+  .sl-table .stDataFrame, .sl-table .stTable {
+    border:1px solid var(--divider);
+    border-radius:var(--radius-md);
+    overflow:hidden;
+  }
+  .sl-table thead tr { position:sticky; top:0; background:var(--bg-card); }
+  .sl-table tbody tr:nth-child(even){ background:var(--table-row-alt); }
+  .sl-table tbody tr:hover{ background:color-mix(in srgb, var(--accent-1) 10%, transparent); }
 
 /* Badge link */
 .sl-badge-link {

--- a/app/styles/tokens_dark.css
+++ b/app/styles/tokens_dark.css
@@ -14,6 +14,8 @@
   --warning: #F59E0B;     /* lämmin varoitus */
   --error: #DA3C2B;       /* tiilenpunainen virheväri */
   --divider: rgba(254, 244, 221, 0.12); /* lämmin, kevyt jakaja */
+  --skeleton-highlight: rgba(254, 244, 221, 0.06);
+  --table-row-alt: rgba(254, 244, 221, 0.02);
 
   /* Typography */
   --font-sans: 'Inter', sans-serif;

--- a/app/styles/tokens_light.css
+++ b/app/styles/tokens_light.css
@@ -11,6 +11,8 @@
   --warning: #F59E0B;
   --error: #DA3C2B;
   --divider: rgba(36, 23, 0, 0.12);
+  --skeleton-highlight: rgba(36, 23, 0, 0.06);
+  --table-row-alt: rgba(36, 23, 0, 0.02);
 
   /* Typography */
   --font-sans: 'Inter', sans-serif;


### PR DESCRIPTION
## Summary
- add `--skeleton-highlight` and `--table-row-alt` tokens for dark and light themes
- use `var(--skeleton-highlight)` in skeleton shimmer animation
- use `var(--table-row-alt)` for striped table rows

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c680f8a2e883208247f7cc0fa16fa3