### PR TITLE
codex: ensure theme css replaces block

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -91,8 +91,16 @@ def inject_css():
         p = styles_dir / name
         if p.exists():
             parts.append(p.read_text(encoding="utf-8"))
+    # remove previously injected theme block if present
+    st.markdown(
+        "<script>var e=document.getElementById('sl-theme'); if (e) e.remove();</script>",
+        unsafe_allow_html=True,
+    )
     if parts:
-        st.markdown(f"<style>{'\n'.join(parts)}</style>", unsafe_allow_html=True)
+        st.markdown(
+            f"<style id='sl-theme'>{'\n'.join(parts)}</style>",
+            unsafe_allow_html=True,
+        )
 
 # --------- Nav
 NAV_KEYS = [


### PR DESCRIPTION
## Summary
- add DOM removal of previous theme CSS block
- inject theme CSS using `<style id="sl-theme">` tag for replacement

## Testing
- `python - <<'PY'
import app.app as app
import streamlit as st

calls=[]

def fake_markdown(body, *args, **kwargs):
    calls.append(body)

st.markdown = fake_markdown
try:
    st.session_state.clear()
    st.session_state['theme']='dark'
    app.inject_css()
    st.session_state['theme']='light'
    app.inject_css()
except Exception as e:
    print('EXC',e)
print('len',len(calls))
for c in calls:
    print('---')
    print(c.split('\n')[0])
PY`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c680f94644832097e3079ca20cd581