### PR TITLE
Remove theme selection from UI

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -84,8 +84,7 @@ APP_VERSION = "0.9.1"
 
 def inject_css():
     styles_dir = ROOT / "app" / "styles"
-    theme = st.session_state.get("theme", "dark")
-    token_file = f"tokens_{theme}.css"
+    token_file = "tokens_dark.css"
     parts = []
     for name in [token_file, "layout.css", "components.css", "sidebar.css", "animations.css"]:
         p = styles_dir / name
@@ -141,9 +140,6 @@ def main() -> None:
         bootstrap_sidebar_auto_collapse()
     except Exception:
         pass
-
-    if "theme" not in st.session_state:
-        st.session_state["theme"] = "dark"
 
     login()
 

--- a/app/ui/sidebar.py
+++ b/app/ui/sidebar.py
@@ -41,7 +41,6 @@ def build_sidebar(
     app_version: str,
     go: Callable[[str], None],
     logout: Callable[[], None],
-    inject_css: Callable[[], None] | None = None,
 ) -> None:
     """Render the application sidebar."""
 
@@ -63,16 +62,6 @@ def build_sidebar(
             key="_nav_radio",
             label_visibility="collapsed",
             on_change=lambda: go(st.session_state["_nav_radio"]),
-        )
-
-        theme_options = ["dark", "light"]
-        current_theme = st.session_state.get("theme", "dark")
-        st.selectbox(
-            "Theme",
-            options=theme_options,
-            index=theme_options.index(current_theme),
-            key="theme",
-            on_change=inject_css,
         )
 
         auth = st.session_state.get("auth", {})


### PR DESCRIPTION
## Summary
- drop theme dropdown from sidebar
- always apply dark theme CSS tokens

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c686b56f588320a70a6e65501a31e7