### PR TITLE
codex: cascade delete player dependencies

### DIFF
--- a/app/player_editor.py
+++ b/app/player_editor.py
@@ -294,8 +294,13 @@ def remove_from_players_storage_by_ids(ids: List[str]) -> int:
     client = get_client()
     if not client:
         return 0
+    ids = [str(i) for i in ids]
     try:
-        client.table("players").delete().in_("id", [str(i) for i in ids]).execute()
+        # Delete dependent rows first to avoid FK violations
+        client.table("reports").delete().in_("player_id", ids).execute()
+        client.table("shortlists").delete().in_("player_id", ids).execute()
+        client.table("notes").delete().in_("player_id", ids).execute()
+        client.table("players").delete().in_("id", ids).execute()
     except Exception:
         st.error("❌ Delete failed")
         st.code("".join(traceback.format_exc()), language="text")

--- a/tests/test_player_delete.py
+++ b/tests/test_player_delete.py
@@ -1,0 +1,37 @@
+import pytest
+
+from app import player_editor
+
+
+def test_remove_from_players_storage_by_ids_cascades(monkeypatch):
+    calls = []
+
+    class Table:
+        def __init__(self, name):
+            self.name = name
+        def delete(self):
+            calls.append((self.name, "delete"))
+            return self
+        def in_(self, column, values):
+            calls.append((self.name, "in", column, values))
+            return self
+        def execute(self):
+            calls.append((self.name, "execute"))
+            return self
+    class Client:
+        def table(self, name):
+            calls.append((name, "table"))
+            return Table(name)
+
+    monkeypatch.setattr(player_editor, "get_client", lambda: Client())
+
+    n = player_editor.remove_from_players_storage_by_ids(["a", "b"])
+    assert n == 2
+
+    table_calls = [c for c in calls if c[1] == "table"]
+    assert [c[0] for c in table_calls] == ["reports", "shortlists", "notes", "players"]
+    assert ("reports", "in", "player_id", ["a", "b"]) in calls
+    assert ("shortlists", "in", "player_id", ["a", "b"]) in calls
+    assert ("notes", "in", "player_id", ["a", "b"]) in calls
+    assert ("players", "in", "id", ["a", "b"]) in calls
+    assert calls[-1] == ("players", "execute")


### PR DESCRIPTION
## Summary
- delete dependent reports, shortlists, and notes before removing players
- add unit test ensuring cascading deletion order

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c691958f688320967f382588a9ee45