### PR TITLE
codex: update shortlist removal

### DIFF
--- a/tests/test_player_delete.py
+++ b/tests/test_player_delete.py
@@ -9,14 +9,39 @@ def test_remove_from_players_storage_by_ids_cascades(monkeypatch):
     class Table:
         def __init__(self, name):
             self.name = name
+            self.mode = None
         def delete(self):
             calls.append((self.name, "delete"))
+            self.mode = "delete"
             return self
         def in_(self, column, values):
             calls.append((self.name, "in", column, values))
             return self
+        def select(self, cols):
+            calls.append((self.name, "select", cols))
+            self.mode = "select"
+            return self
+        def contains(self, column, values):
+            calls.append((self.name, "contains", column, values))
+            return self
+        def update(self, data):
+            calls.append((self.name, "update", data))
+            self.mode = "update"
+            return self
+        def eq(self, column, value):
+            calls.append((self.name, "eq", column, value))
+            return self
         def execute(self):
             calls.append((self.name, "execute"))
+            if self.name == "shortlists" and self.mode == "select":
+                class Res:
+                    pass
+                res = Res()
+                res.data = [
+                    {"id": "s1", "player_ids": ["a", "x"]},
+                    {"id": "s2", "player_ids": ["b"]},
+                ]
+                return res
             return self
     class Client:
         def table(self, name):
@@ -29,9 +54,25 @@ def test_remove_from_players_storage_by_ids_cascades(monkeypatch):
     assert n == 2
 
     table_calls = [c for c in calls if c[1] == "table"]
-    assert [c[0] for c in table_calls] == ["reports", "shortlists", "notes", "players"]
+    assert table_calls[0][0] == "reports"
+    assert table_calls[-1][0] == "players"
+
+    # Ensure cascading deletes
     assert ("reports", "in", "player_id", ["a", "b"]) in calls
-    assert ("shortlists", "in", "player_id", ["a", "b"]) in calls
     assert ("notes", "in", "player_id", ["a", "b"]) in calls
     assert ("players", "in", "id", ["a", "b"]) in calls
+
+    # Shortlists should be selected and updated, not deleted
+    assert ("shortlists", "delete") not in [c[:2] for c in calls]
+    assert ("shortlists", "select", "id, player_ids") in calls
+    assert ("shortlists", "contains", "player_ids", ["a", "b"]) in calls
+    assert ("shortlists", "update", {"player_ids": ["x"]}) in calls
+    assert ("shortlists", "eq", "id", "s1") in calls
+    assert ("shortlists", "update", {"player_ids": []}) in calls
+    assert ("shortlists", "eq", "id", "s2") in calls
+
+    # Updates must execute before player deletions
+    shortlist_exec_indices = [i for i, c in enumerate(calls) if c[0] == "shortlists" and c[1] == "execute"]
+    players_exec_index = calls.index(("players", "execute"))
+    assert shortlist_exec_indices and max(shortlist_exec_indices) < players_exec_index
     assert calls[-1] == ("players", "execute")


### PR DESCRIPTION
## Summary
- Update player deletion to trim IDs from shortlists instead of deleting rows
- Expand player deletion tests to mock shortlist updates and verify call order

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c692e9a5e48320a80e6dfd66f9e2d5