### PR TITLE
Add notes table migration

### DIFF
--- a/supabase/005_create_notes_table.sql
+++ b/supabase/005_create_notes_table.sql
@@ -1,0 +1,10 @@
+-- 005_create_notes_table.sql
+-- Create notes table for player notes
+
+create table if not exists public.notes (
+  id uuid primary key default gen_random_uuid(),
+  player_id uuid references public.players(id) on delete cascade,
+  text text not null,
+  created_at timestamptz default now(),
+  tags text[]
+);


### PR DESCRIPTION
## Summary
- create `notes` table with player reference and tags

## Testing
- `pytest`
- `psql -f supabase/005_create_notes_table.sql` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c692fb151c83209cafb1ab104b6fc9