### PR TITLE
codex: add player note helpers and UI

### DIFF
--- a/app/player_editor.py
+++ b/app/player_editor.py
@@ -299,7 +299,7 @@ def remove_from_players_storage_by_ids(ids: List[str]) -> int:
         # Delete dependent rows first to avoid FK violations
         client.table("reports").delete().in_("player_id", ids).execute()
         client.table("shortlists").delete().in_("player_id", ids).execute()
-        client.table("notes").delete().in_("player_id", ids).execute()
+        client.table("player_notes").delete().in_("player_id", ids).execute()
         client.table("players").delete().in_("id", ids).execute()
     except Exception:
         st.error("❌ Delete failed")

--- a/app/player_notes.py
+++ b/app/player_notes.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+from typing import List, Optional, Dict, Any
+
+import streamlit as st
+from postgrest.exceptions import APIError
+
+from app.supabase_client import get_client
+
+
+TABLE = "player_notes"
+
+
+def get_player_notes(player_id: str) -> List[Dict[str, Any]]:
+    """Return notes for a player ordered by created_at descending."""
+    client = get_client()
+    if not client or not player_id:
+        return []
+    try:
+        res = (
+            client.table(TABLE)
+            .select("*")
+            .eq("player_id", player_id)
+            .order("created_at", desc=True)
+            .execute()
+        )
+        data = res.data or []
+        return data if isinstance(data, list) else []
+    except APIError as e:  # pragma: no cover - network
+        st.error("Failed to load notes")
+        print(e)
+        return []
+
+
+def add_player_note(player_id: str, text: str, tags: Optional[List[str]] = None) -> Optional[Dict[str, Any]]:
+    """Insert a new note for a player."""
+    client = get_client()
+    if not client or not player_id or not text:
+        return None
+    payload: Dict[str, Any] = {"player_id": player_id, "text": text.strip()}
+    if tags:
+        payload["tags"] = tags
+    try:
+        res = client.table(TABLE).insert(payload).execute()
+        data = res.data or []
+        if isinstance(data, list) and data:
+            return data[0]
+    except APIError as e:  # pragma: no cover - network
+        st.error("Failed to add note")
+        print(e)
+    return None
+
+
+def delete_player_note(note_id: str) -> bool:
+    """Delete a note by id."""
+    client = get_client()
+    if not client or not note_id:
+        return False
+    try:
+        client.table(TABLE).delete().eq("id", note_id).execute()
+        return True
+    except APIError as e:  # pragma: no cover - network
+        st.error("Failed to delete note")
+        print(e)
+        return False

--- a/app/player_preview.py
+++ b/app/player_preview.py
@@ -6,6 +6,11 @@ import re
 import pandas as pd
 import streamlit as st
 
+from app.player_notes import (
+    get_player_notes,
+    add_player_note,
+    delete_player_note,
+)
 def _inject_css_once(key: str, css_html: str):
     sskey = f"__css_injected__{key}"
     if not st.session_state.get(sskey):
@@ -333,6 +338,35 @@ def show_player_preview():
                 tags = [t.strip() for t in tags.split(",") if t.strip()]
             if isinstance(tags, list) and tags:
                 st.write("**Tags:** " + ", ".join(tags))
+
+    st.markdown("---")
+
+    # Quick notes
+    st.subheader("🗒️ Quick notes")
+    note_key = f"pp_note_{player_id}"
+    note_text = st.text_area("Write a note", key=note_key, height=100)
+    if st.button("Save note", key=f"pp_save_{player_id}"):
+        txt = (note_text or "").strip()
+        if txt:
+            add_player_note(player_id, txt)
+            st.success("Saved.")
+            st.session_state[note_key] = ""
+            st.experimental_rerun()
+        else:
+            st.warning("Write something first.")
+
+    notes = get_player_notes(player_id)
+    if not notes:
+        st.caption("No notes yet.")
+    else:
+        for n in notes:
+            cols = st.columns([4, 1])
+            ts = (n.get("created_at", "") or "")[:16].replace("T", " ")
+            cols[0].markdown(f"**{ts}** — {n.get('text','')}")
+            nid = n.get("id")
+            if cols[1].button("Delete", key=f"pp_del_{nid}"):
+                delete_player_note(str(nid))
+                st.experimental_rerun()
 
     st.markdown("---")
 

--- a/tests/test_player_delete.py
+++ b/tests/test_player_delete.py
@@ -29,9 +29,9 @@ def test_remove_from_players_storage_by_ids_cascades(monkeypatch):
     assert n == 2
 
     table_calls = [c for c in calls if c[1] == "table"]
-    assert [c[0] for c in table_calls] == ["reports", "shortlists", "notes", "players"]
+    assert [c[0] for c in table_calls] == ["reports", "shortlists", "player_notes", "players"]
     assert ("reports", "in", "player_id", ["a", "b"]) in calls
     assert ("shortlists", "in", "player_id", ["a", "b"]) in calls
-    assert ("notes", "in", "player_id", ["a", "b"]) in calls
+    assert ("player_notes", "in", "player_id", ["a", "b"]) in calls
     assert ("players", "in", "id", ["a", "b"]) in calls
     assert calls[-1] == ("players", "execute")


### PR DESCRIPTION
## Summary
- add supabase-backed helpers for per-player notes
- show Quick notes section in player preview
- cascade delete player_notes when removing players

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c692fdc8d483209e4078eba26c095b