### PR TITLE
codex: refactor shortlist cleanup in player deletion

### DIFF
--- a/tests/test_player_delete.py
+++ b/tests/test_player_delete.py
@@ -47,22 +47,22 @@ def test_remove_from_players_storage_by_ids_cascades(monkeypatch):
     table_calls = [c for c in calls if c[1] == "table"]
     assert [c[0] for c in table_calls] == [
         "reports",
-        "shortlists",
+        "shortlist_items",
         "player_notes",
         "players",
     ]
 
     # Correct filters applied
     assert ("reports", "in", "player_id", ["a", "b"]) in calls
-    assert ("shortlists", "in", "player_id", ["a", "b"]) in calls
+    assert ("shortlist_items", "in", "player_id", ["a", "b"]) in calls
     assert ("player_notes", "in", "player_id", ["a", "b"]) in calls
     assert ("players", "in", "id", ["a", "b"]) in calls
 
     # Executes happen; players execute is last
     exec_indices = {name: [i for i, x in enumerate(calls) if x[:2] == (name, "execute")] for name in [
-        "reports", "shortlists", "player_notes", "players"
+        "reports", "shortlist_items", "player_notes", "players"
     ]}
-    assert all(exec_indices[name] for name in ["reports", "shortlists", "player_notes", "players"])  # all executed
+    assert all(exec_indices[name] for name in ["reports", "shortlist_items", "player_notes", "players"])  # all executed
     assert calls[-1] == ("players", "execute")
 
     # Ensure we are not doing array-based shortlist surgery anymore
@@ -70,6 +70,9 @@ def test_remove_from_players_storage_by_ids_cascades(monkeypatch):
         ("shortlists", "select", "id, player_ids"),
         ("shortlists", "contains", "player_ids", ["a", "b"]),
         ("shortlists", "update", {"player_ids": ["x"]}),
+        ("shortlist_items", "select", "id, player_ids"),
+        ("shortlist_items", "contains", "player_ids", ["a", "b"]),
+        ("shortlist_items", "update", {"player_ids": ["x"]}),
     ]
     for f in forbidden:
         assert f not in calls


### PR DESCRIPTION
## Summary
- delete player shortlist memberships directly from `shortlist_items`
- log Supabase API errors during player removal
- update player deletion test for `shortlist_items`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c69626966083209d8068a58ac118fb