### PR TITLE
codex: refactor shortlists into join table

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -39,3 +39,7 @@ PY
 ```
 
 Replace `'data'` with your bucket name and adjust file paths as needed.
+
+## Migrations
+
+- `006_shortlists_refactor.sql` drops `player_ids` from `public.shortlists` and adds a normalized `public.shortlist_items` table with a unique `(shortlist_id, player_id)` constraint.

--- a/supabase/006_shortlists_refactor.sql
+++ b/supabase/006_shortlists_refactor.sql
@@ -1,0 +1,15 @@
+-- 006_shortlists_refactor.sql
+-- Normalize shortlist players into a separate table.
+
+-- Drop old array column if it exists
+alter table if exists public.shortlists
+  drop column if exists player_ids;
+
+-- Table linking shortlists and players
+create table if not exists public.shortlist_items (
+  id uuid primary key default gen_random_uuid(),
+  shortlist_id uuid references public.shortlists(id) on delete cascade,
+  player_id uuid references public.players(id) on delete cascade,
+  created_at timestamptz default now(),
+  unique(shortlist_id, player_id)
+);


### PR DESCRIPTION
## Summary
- normalize shortlists by removing player_ids array and introducing a shortlist_items join table
- document migration details in README

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c69626b35c832096de899a35a7bb59