### PR TITLE
codex: adjust player deletion for shortlist items

### DIFF
--- a/app/player_editor.py
+++ b/app/player_editor.py
@@ -4,7 +4,7 @@
 
 Fixes:
 - Resolved merge conflicts in `remove_from_players_storage_by_ids`.
-- Uses row-per-membership `shortlists` table with `player_id` for cleanup.
+- Uses row-per-membership `shortlist_items` table with `player_id` for cleanup.
 - Cleans up `player_notes` before deleting players.
 - Removed stray ``KORJAA TÄÄ`` that caused a SyntaxError.
 - Minor defensive guards; no functional changes to UI.
@@ -364,7 +364,7 @@ def upsert_player_storage(player: dict) -> str:
 def remove_from_players_storage_by_ids(ids: List[str]) -> int:
     """Remove players and dependent rows in a safe order.
 
-    Assumes `shortlists` has one row per membership with a `player_id` column,
+    Assumes `shortlist_items` has one row per membership with a `player_id` column,
     and player notes reside in `player_notes` with `player_id`.
     """
     client = get_client()
@@ -376,7 +376,7 @@ def remove_from_players_storage_by_ids(ids: List[str]) -> int:
     try:
         # Delete dependents first to avoid FK violations
         client.table("reports").delete().in_("player_id", ids).execute()
-        client.table("shortlists").delete().in_("player_id", ids).execute()
+        client.table("shortlist_items").delete().in_("player_id", ids).execute()
         client.table("player_notes").delete().in_("player_id", ids).execute()
         client.table("players").delete().in_("id", ids).execute()
     except Exception:

--- a/tests/test_player_delete.py
+++ b/tests/test_player_delete.py
@@ -10,25 +10,32 @@ def test_remove_from_players_storage_by_ids_cascades(monkeypatch):
     class Table:
         def __init__(self, name):
             self.name = name
+
         def delete(self):
             calls.append((self.name, "delete"))
             return self
+
         def in_(self, column, values):
             calls.append((self.name, "in", column, list(values)))
             return self
+
         # no-ops to guard against accidental calls
         def select(self, cols):
             calls.append((self.name, "select", cols))
             return self
+
         def contains(self, column, values):
             calls.append((self.name, "contains", column, list(values)))
             return self
+
         def update(self, data):
             calls.append((self.name, "update", data))
             return self
+
         def eq(self, column, value):
             calls.append((self.name, "eq", column, value))
             return self
+
         def execute(self):
             calls.append((self.name, "execute"))
             return self
@@ -47,29 +54,65 @@ def test_remove_from_players_storage_by_ids_cascades(monkeypatch):
     table_calls = [c for c in calls if c[1] == "table"]
     assert [c[0] for c in table_calls] == [
         "reports",
-        "shortlists",
+        "shortlist_items",
         "player_notes",
         "players",
     ]
 
     # Correct filters applied
     assert ("reports", "in", "player_id", ["a", "b"]) in calls
-    assert ("shortlists", "in", "player_id", ["a", "b"]) in calls
+    assert ("shortlist_items", "in", "player_id", ["a", "b"]) in calls
     assert ("player_notes", "in", "player_id", ["a", "b"]) in calls
     assert ("players", "in", "id", ["a", "b"]) in calls
 
-    # Executes happen; players execute is last
-    exec_indices = {name: [i for i, x in enumerate(calls) if x[:2] == (name, "execute")] for name in [
-        "reports", "shortlists", "player_notes", "players"
-    ]}
-    assert all(exec_indices[name] for name in ["reports", "shortlists", "player_notes", "players"])  # all executed
+    # Executes happen; shortlist item execute precedes players
+    exec_indices = {
+        name: [i for i, x in enumerate(calls) if x[:2] == (name, "execute")]
+        for name in ["reports", "shortlist_items", "player_notes", "players"]
+    }
+    assert all(
+        exec_indices[name]
+        for name in ["reports", "shortlist_items", "player_notes", "players"]
+    )
+    assert exec_indices["shortlist_items"][0] < exec_indices["players"][0]
     assert calls[-1] == ("players", "execute")
 
-    # Ensure we are not doing array-based shortlist surgery anymore
-    forbidden = [
-        ("shortlists", "select", "id, player_ids"),
-        ("shortlists", "contains", "player_ids", ["a", "b"]),
-        ("shortlists", "update", {"player_ids": ["x"]}),
-    ]
-    for f in forbidden:
-        assert f not in calls
+    # Ensure we are not touching `shortlists` table at all
+    assert all(c[0] != "shortlists" for c in calls)
+
+
+def test_remove_from_players_storage_by_ids_no_shortlist_items(monkeypatch):
+    calls = []
+
+    class Table:
+        def __init__(self, name):
+            self.name = name
+
+        def delete(self):
+            calls.append((self.name, "delete"))
+            return self
+
+        def in_(self, column, values):
+            calls.append((self.name, "in", column, list(values)))
+            return self
+
+        def execute(self):
+            calls.append((self.name, "execute"))
+            # simulate Supabase returning no matching rows
+            return type("Resp", (), {"data": []})()
+
+    class Client:
+        def table(self, name):
+            calls.append((name, "table"))
+            return Table(name)
+
+    monkeypatch.setattr(player_editor, "get_client", lambda: Client())
+
+    n = player_editor.remove_from_players_storage_by_ids(["z"])
+    assert n == 1
+
+    assert ("shortlist_items", "delete") in calls
+    assert ("shortlist_items", "execute") in calls
+    assert all(c[0] != "shortlists" for c in calls)
+    # still deletes player afterwards
+    assert calls[-1] == ("players", "execute")


### PR DESCRIPTION
## Summary
- remove players using `shortlist_items` rows instead of `shortlists`
- update cascade deletion test to expect `shortlist_items` cleanup
- add test for delete behavior when no shortlist items match

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c6962812548320ae4296ede51bd52d