### PR TITLE
Add quick notes page with player search

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -75,6 +75,9 @@ show_shortlist_management_page = _safe_import(
 show_export_page = _safe_import("export", "app.export_page", "show_export_page")
 login = _safe_import("login", "app.login", "login")
 logout = _safe_import("logout", "app.login", "logout")
+show_quick_notes_page = _safe_import(
+    "notes", "app.quick_notes_page", "show_quick_notes_page"
+)
 
 APP_TITLE = "ScoutLens"
 APP_TAGLINE = "LATAM scouting toolkit"
@@ -108,6 +111,7 @@ NAV_KEYS = [
     "Shortlists",
     "Manage Shortlists",
     "Players",
+    "Notes",
     "Export",
 ]
 NAV_LABELS = {
@@ -116,6 +120,7 @@ NAV_LABELS = {
     "Shortlists": "⭐ Shortlists",
     "Manage Shortlists": "🗑️ Manage Shortlists",
     "Players": "👤 Players",
+    "Notes": "🗒️ Notes",
     "Export": "⬇️ Export",
 }
 LEGACY_REMAP = {
@@ -131,6 +136,7 @@ PAGE_FUNCS = {
     "Shortlists": show_shortlists_page,
     "Manage Shortlists": show_shortlist_management_page,
     "Players": show_player_management_page,
+    "Notes": show_quick_notes_page,
     "Export": show_export_page,
 }
 

--- a/app/pages/03_Notes.py
+++ b/app/pages/03_Notes.py
@@ -1,0 +1,12 @@
+"""Streamlit multipage entry for the Notes view."""
+from __future__ import annotations
+
+from app.quick_notes_page import show_quick_notes_page
+
+
+def main() -> None:
+    show_quick_notes_page()
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/app/pages/__init__.py
+++ b/app/pages/__init__.py
@@ -1,0 +1,2 @@
+"""Streamlit multipage stubs."""
+from __future__ import annotations

--- a/app/quick_notes_page.py
+++ b/app/quick_notes_page.py
@@ -1,0 +1,194 @@
+"""Streamlit page for managing player quick notes."""
+from __future__ import annotations
+
+from typing import Dict, List, Optional
+
+import streamlit as st
+from postgrest.exceptions import APIError
+
+from app.supabase_client import get_client
+from app.services.quick_notes import (
+    add_quick_note,
+    delete_quick_note,
+    list_quick_notes,
+)
+
+PAGE_KEY = "quick_notes__"
+
+
+def _sb():
+    return get_client()
+
+
+def _search_players(query: str, limit: int = 20) -> List[Dict]:
+    client = _sb()
+    q = (
+        client.table("players")
+        .select("id,name,current_club,position,nationality")
+        .order("name")
+        .limit(limit)
+    )
+    query = (query or "").strip()
+    if query:
+        q = q.ilike("name", f"%{query}%")
+    try:
+        data = q.execute().data
+        return data or []
+    except APIError as exc:  # pragma: no cover - network interaction
+        st.error(f"Failed to search players: {exc}")
+        return []
+
+
+def _create_player_minimal(
+    name: str,
+    position: Optional[str] = None,
+    current_club: Optional[str] = None,
+    nationality: Optional[str] = None,
+    preferred_foot: Optional[str] = None,
+) -> Optional[str]:
+    client = _sb()
+    payload: Dict[str, Optional[str]] = {
+        "name": name.strip(),
+        "position": (position or "").strip() or None,
+        "current_club": (current_club or "").strip() or None,
+        "nationality": (nationality or "").strip() or None,
+        "preferred_foot": (preferred_foot or "").strip() or None,
+    }
+    try:
+        rows = client.table("players").insert(payload).execute().data or []
+        return rows[0]["id"] if rows else None
+    except APIError as exc:  # pragma: no cover - network interaction
+        st.error(f"Failed to create player: {exc}")
+        return None
+
+
+def _format_timestamp(ts: Optional[str]) -> str:
+    if not ts:
+        return "—"
+    clean = ts.replace("T", " ")
+    clean = clean.split("+")[0]
+    return clean[:16]
+
+
+def show_quick_notes_page() -> None:
+    st.title("📝 Notes")
+
+    sel_id_key = PAGE_KEY + "player_id"
+    sel_label_key = PAGE_KEY + "player_label"
+    st.session_state.setdefault(sel_id_key, None)
+    st.session_state.setdefault(sel_label_key, None)
+
+    st.subheader("Player")
+    col_search, col_add = st.columns([3, 1])
+
+    with col_search:
+        query = st.text_input(
+            "Search by name",
+            key=PAGE_KEY + "search",
+            placeholder="Type player name…",
+        )
+        results = _search_players(query) if query else []
+        labels = [f"{p['name']} ({p.get('current_club') or '—'})" for p in results]
+        id_by_label = {label: player["id"] for label, player in zip(labels, results)}
+
+        default_label = st.session_state.get(sel_label_key)
+        placeholder_label = "— Select a player —"
+        options: List[str] = [placeholder_label] + labels
+        if default_label and default_label in labels:
+            default_index = options.index(default_label)
+        else:
+            default_index = 0
+
+        selected_option = st.selectbox(
+            "Results",
+            options,
+            index=default_index,
+            key=PAGE_KEY + "results",
+        )
+        if selected_option and selected_option != placeholder_label:
+            st.session_state[sel_id_key] = id_by_label[selected_option]
+            st.session_state[sel_label_key] = selected_option
+
+    with col_add:
+        with st.popover("＋ New Player"):
+            with st.form(PAGE_KEY + "add_player_form", clear_on_submit=True):
+                name = st.text_input("Name*", value="")
+                colp = st.columns(2)
+                position = colp[0].text_input("Position", value="")
+                current_club = colp[1].text_input("Current club", value="")
+                coln = st.columns(2)
+                nationality = coln[0].text_input("Nationality", value="")
+                preferred_foot = coln[1].selectbox(
+                    "Preferred foot",
+                    ["", "Right", "Left", "Both"],
+                )
+                if st.form_submit_button("Create"):
+                    if not name.strip():
+                        st.warning("Name is required")
+                    else:
+                        new_id = _create_player_minimal(
+                            name,
+                            position,
+                            current_club,
+                            nationality,
+                            preferred_foot,
+                        )
+                        if new_id:
+                            st.toast(f"Player '{name}' created", icon="✅")
+                            st.session_state[sel_id_key] = new_id
+                            st.session_state[sel_label_key] = (
+                                f"{name} ({current_club or '—'})"
+                            )
+                            st.session_state[PAGE_KEY + "search"] = name
+                            st.rerun()
+
+    player_id = st.session_state.get(sel_id_key)
+    if not player_id:
+        st.info(
+            "Search and select a player, or create a new one to start taking notes."
+        )
+        return
+
+    st.divider()
+    st.subheader("Quick Notes")
+
+    with st.form(PAGE_KEY + f"add_note_form_{player_id}", clear_on_submit=True):
+        note_text = st.text_area(
+            "Add a quick note",
+            height=90,
+            placeholder="Short observation…",
+        )
+        submitted = st.form_submit_button("Save Note")
+        if submitted and note_text.strip():
+            if add_quick_note(player_id, note_text):
+                st.toast("Note saved", icon="✅")
+                st.rerun()
+        elif submitted:
+            st.warning("Note is empty.")
+
+    notes = list_quick_notes(player_id)
+
+    if not notes:
+        st.caption("No notes yet for this player.")
+        return
+
+    for note in notes:
+        container = st.container()
+        with container:
+            col_content, col_actions = st.columns([9, 1])
+            with col_content:
+                st.markdown(note.get("content", ""))
+                st.caption(
+                    "Created: "
+                    + _format_timestamp(note.get("created_at"))
+                    + "  •  Updated: "
+                    + _format_timestamp(note.get("updated_at"))
+                )
+            with col_actions:
+                if st.button(
+                    "🗑️ Delete",
+                    key=PAGE_KEY + f"del_{note.get('id')}",
+                ):
+                    if delete_quick_note(str(note.get("id"))):
+                        st.toast("Note deleted", icon="🗑️")
+                        st.rerun()

--- a/app/services/quick_notes.py
+++ b/app/services/quick_notes.py
@@ -1,0 +1,84 @@
+"""Helpers for interacting with quick notes."""
+from __future__ import annotations
+
+from typing import Dict, List
+
+import streamlit as st
+from postgrest.exceptions import APIError
+
+from app.supabase_client import get_client
+
+
+__all__ = [
+    "list_quick_notes",
+    "add_quick_note",
+    "delete_quick_note",
+    "fetch_note_counts_by_player",
+]
+
+
+def list_quick_notes(player_id: str) -> List[Dict]:
+    """Return quick notes for a player ordered by newest first."""
+    if not player_id:
+        return []
+    sb = get_client()
+    try:
+        resp = (
+            sb.table("quick_notes")
+            .select("id,content,created_at,updated_at")
+            .eq("player_id", player_id)
+            .order("created_at", desc=True)
+            .execute()
+        )
+        return resp.data or []
+    except APIError as exc:  # pragma: no cover - network interaction
+        st.error(f"Failed to load notes: {exc}")
+        return []
+
+
+def add_quick_note(player_id: str, content: str) -> bool:
+    """Insert a quick note for a player."""
+    if not player_id:
+        st.warning("Select a player before adding notes.")
+        return False
+    if not content or not content.strip():
+        st.warning("Note is empty.")
+        return False
+    sb = get_client()
+    try:
+        sb.table("quick_notes").insert(
+            {"player_id": player_id, "content": content.strip()}
+        ).execute()
+        return True
+    except APIError as exc:  # pragma: no cover - network interaction
+        st.error(f"Failed to add note: {exc}")
+        return False
+
+
+def delete_quick_note(note_id: str) -> bool:
+    """Delete a quick note by id."""
+    if not note_id:
+        return False
+    sb = get_client()
+    try:
+        sb.table("quick_notes").delete().eq("id", note_id).execute()
+        return True
+    except APIError as exc:  # pragma: no cover - network interaction
+        st.error(f"Failed to delete note: {exc}")
+        return False
+
+
+def fetch_note_counts_by_player() -> Dict[str, int]:
+    """Fetch quick note counts grouped by player id."""
+    sb = get_client()
+    try:
+        data = (
+            sb.table("quick_note_counts")
+            .select("player_id,note_count")
+            .execute()
+            .data
+        )
+        return {row["player_id"]: row["note_count"] for row in (data or [])}
+    except APIError as exc:  # pragma: no cover - network interaction
+        st.error(f"Failed to load note counts: {exc}")
+        return {}

--- a/supabase/009_quick_notes_view.sql
+++ b/supabase/009_quick_notes_view.sql
@@ -1,0 +1,9 @@
+-- View for quick note counts (idempotent)
+create or replace view public.quick_note_counts as
+select player_id, count(*)::int as note_count
+from public.quick_notes
+group by player_id;
+
+-- Helpful index for player-scoped queries
+create index if not exists idx_quick_notes_player_created
+on public.quick_notes (player_id, created_at desc);


### PR DESCRIPTION
## Summary
- add Supabase view and index for quick note counts and ordering
- implement quick note service helpers
- introduce Streamlit notes page with player search, inline creation, and note management

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ce44c2eb708320bbd7fedf9fae3109