### PR TITLE
Load quick notes players by default

### DIFF
--- a/app/quick_notes_page.py
+++ b/app/quick_notes_page.py
@@ -93,7 +93,7 @@ def show_quick_notes_page() -> None:
             key=PAGE_KEY + "search",
             placeholder="Type player name…",
         )
-        results = _search_players(query) if query else []
+        results = _search_players(query)
         labels = [f"{p['name']} ({p.get('current_club') or '—'})" for p in results]
         id_by_label = {label: player["id"] for label, player in zip(labels, results)}
 


### PR DESCRIPTION
## Summary
- call the player search helper even when the query is blank so the selectbox populates immediately

## Testing
- not run (UI change)

------
https://chatgpt.com/codex/tasks/task_e_68ce49bdc0288320b4c9446e768cbdbf