### PR TITLE
Rename main page and notes labels

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -41,7 +41,7 @@ build_sidebar = importlib.import_module("app.ui.sidebar").__getattribute__(
     "build_sidebar"
 )
 
-st.set_page_config(page_title="ScoutLens", layout="wide", initial_sidebar_state="expanded")
+st.set_page_config(page_title="Main", layout="wide", initial_sidebar_state="expanded")
 
 # ---- Page imports (Streamlit-safe wrapper)
 
@@ -120,7 +120,7 @@ NAV_LABELS = {
     "Shortlists": "⭐ Shortlists",
     "Manage Shortlists": "🗑️ Manage Shortlists",
     "Players": "👤 Players",
-    "Notes": "🗒️ Notes",
+    "Notes": "🗒️ Quick notes",
     "Export": "⬇️ Export",
 }
 LEGACY_REMAP = {

--- a/app/pages/03_Notes.py
+++ b/app/pages/03_Notes.py
@@ -1,7 +1,12 @@
 """Streamlit multipage entry for the Notes view."""
 from __future__ import annotations
 
+import streamlit as st
+
 from app.quick_notes_page import show_quick_notes_page
+
+
+st.set_page_config(page_title="Quick notes")
 
 
 def main() -> None:


### PR DESCRIPTION
## Summary
- rename the main script's page title to "Main" so Streamlit navigation shows the desired name
- retitle the notes entry to "Quick notes" in both the main sidebar and multipage wrapper

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cf8ab15d908320a3f4153efccfd8b2