### PR TITLE
codex: fix Streamlit image column width usage

### DIFF
--- a/app/player_preview.py
+++ b/app/player_preview.py
@@ -283,7 +283,7 @@ def show_player_preview():
     with c1:
         photo = _find_photo_for(row)
         if photo and photo.exists():
-            st.image(str(photo), use_container_width=True)
+            st.image(str(photo), use_column_width=True)
         else:
             st.info("No photo. You can upload one below.")
 

--- a/app/ui/sidebar.py
+++ b/app/ui/sidebar.py
@@ -56,7 +56,7 @@ def build_sidebar(
         st.markdown("<div class='sidebar-shell'>", unsafe_allow_html=True)
         st.markdown("<div class='sidebar-header'>", unsafe_allow_html=True)
         st.markdown("<div class='sidebar-logo'>", unsafe_allow_html=True)
-        st.image(str(root / "assets" / "logo.png"), use_container_width=True)
+        st.image(str(root / "assets" / "logo.png"), use_column_width=True)
         st.markdown("</div>", unsafe_allow_html=True)
 
         tagline_html = (


### PR DESCRIPTION
## Summary
- update the sidebar logo and player preview photo rendering to use `use_column_width=True` so they stay compatible with newer Streamlit releases

## Testing
- streamlit run app/app.py --server.headless true --server.port 8501 (timeout 10s)


------
https://chatgpt.com/codex/tasks/task_e_68cf96d9a4e88320b917413817821bf9