### PR TITLE
codex: enforce anon Supabase sync and add admin sync script

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -12,7 +12,7 @@ You can verify the package imports with:
 
 ### Supabase Sync
 
-Configure a `[supabase]` block in your Streamlit secrets to enable optional Supabase storage. Functions in `app/sync_utils.py` and `app/teams_store.py` will then read and write data to your Supabase tables.
+Configure a `[supabase]` block in your Streamlit secrets to enable optional Supabase storage. Functions in `app/sync_utils.py` and `app/teams_store.py` will then read data (and write when an authenticated session is active) to your Supabase tables.
 
 #### Developer Setup
 
@@ -26,19 +26,17 @@ url = "https://<project>.supabase.co"
 anon_key = "<public-anon-key>"
 ```
 
-The application reads and writes JSON data to Supabase storage through `app/sync_utils.py`. Example usage of the utilities:
+`app/sync_utils.py` now reuses the shared anon Supabase client and will only perform writes when the current Streamlit session has authenticated through Supabase Auth. Reads continue to work for public tables. For admin/CLI tasks that require the service role key, use `scripts/supabase_admin_sync.py` outside the Streamlit runtime:
 
 ```bash
-python - <<'PY'
-from pathlib import Path
-from sync_utils import push_json, pull_json
+export SUPABASE_URL="https://<project>.supabase.co"
+export SUPABASE_SERVICE_ROLE_KEY="<private-service-role-key>"
 
-push_json('data', 'players.json', Path('local_players.json'))
-pull_json('data', 'players.json', Path('downloaded_players.json'))
-PY
+python scripts/supabase_admin_sync.py pull players ./backup/players.json
+python scripts/supabase_admin_sync.py push players ./backup/players.json
 ```
 
-Replace `'data'` with your bucket name and adjust file paths as needed.
+Replace `players` with the target table name and adjust file paths as needed.
 
 ## Migrations
 

--- a/docs/reports-first-mvp.md
+++ b/docs/reports-first-mvp.md
@@ -98,6 +98,8 @@ url = "https://gqiaicnmnoxmqwbeyflp.supabase.co"
 anon_key = "<KEEP FROM SECRETS>"
 ```
 
+> The Streamlit runtime only uses the anon key. Admin tooling that needs the service role key now lives in `scripts/supabase_admin_sync.py` and should be executed outside the deployed app with `SUPABASE_SERVICE_ROLE_KEY` set in the environment.
+
 Python client:
 
 ```python

--- a/scripts/supabase_admin_sync.py
+++ b/scripts/supabase_admin_sync.py
@@ -1,0 +1,75 @@
+"""Admin-only Supabase sync helpers using the service role key.
+
+This module is intentionally kept outside the Streamlit runtime. It expects
+`SUPABASE_URL` and `SUPABASE_SERVICE_ROLE_KEY` environment variables to be
+present and should only be used for trusted CLI/admin tasks.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+from typing import Tuple
+
+from supabase import create_client
+
+
+def _service_client():
+    url = os.getenv("SUPABASE_URL")
+    key = os.getenv("SUPABASE_SERVICE_ROLE_KEY")
+    if not url or not key:
+        raise RuntimeError(
+            "Set SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY before running admin sync commands."
+        )
+    return create_client(url, key)
+
+
+def push_json(table: str, local_fp: Path) -> Tuple[bool, str]:
+    """Read a local JSON file and upsert rows into a Supabase table."""
+    try:
+        sb = _service_client()
+        payload = json.loads(local_fp.read_text(encoding="utf-8"))
+        if isinstance(payload, dict):
+            payload = [payload]
+        sb.table(table).upsert(payload).execute()
+        return True, f"Upserted {len(payload)} rows into {table}"
+    except Exception as exc:  # pragma: no cover - network/admin failures
+        return False, str(exc)
+
+
+def pull_json(table: str, local_fp: Path) -> Tuple[bool, str]:
+    """Fetch rows from a Supabase table and write them to a local JSON file."""
+    try:
+        sb = _service_client()
+        res = sb.table(table).select("*").execute()
+        data = res.data if hasattr(res, "data") else res
+        local_fp.parent.mkdir(parents=True, exist_ok=True)
+        local_fp.write_text(json.dumps(data, ensure_ascii=False, indent=2), encoding="utf-8")
+        return True, f"Downloaded {len(data)} rows from {table}"
+    except Exception as exc:  # pragma: no cover - network/admin failures
+        return False, str(exc)
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Supabase admin sync utilities")
+    parser.add_argument("action", choices=["push", "pull"], help="Direction of sync")
+    parser.add_argument("table", help="Target table name")
+    parser.add_argument("path", help="Local JSON file path")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = _parse_args()
+    path = Path(args.path)
+    if args.action == "push":
+        ok, msg = push_json(args.table, path)
+    else:
+        ok, msg = pull_json(args.table, path)
+    print(msg)
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- replace the legacy service-role Supabase client in `app/sync_utils.py` with the shared anon client and require an authenticated session before writes
- add `scripts/supabase_admin_sync.py` for trusted CLI usage with the service role key pulled from environment variables
- document the new workflow in the README and docs, clarifying that the Streamlit runtime no longer uses the service role key

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cf9980cd2c8320b6a93f2ea7a59449