### PR TITLE
codex: integrate supabase auth session handling

### DIFF
--- a/app/login.py
+++ b/app/login.py
@@ -1,168 +1,37 @@
-# file: app/login.py
+"""Streamlit authentication gate backed by Supabase email/password auth."""
+
 from __future__ import annotations
 
-import binascii
-import hmac
-import os
-from dataclasses import dataclass
-from datetime import datetime, timedelta, timezone
-from typing import Dict, Optional, Tuple
+from typing import Dict
 
 import streamlit as st
+from supabase import AuthApiError, AuthError
+
+from app.supabase_client import get_client, sign_in as supabase_sign_in, sign_out as supabase_sign_out
 from app.ui import bootstrap_sidebar_auto_collapse
 from app.ui.login_bg import set_login_background
 
 bootstrap_sidebar_auto_collapse()
 
-
-# ============================
-# Password hashing utilities
-# ============================
-def _pbkdf2_sha256(password_bytes: bytes, salt: bytes, iterations: int) -> bytes:
-    import hashlib
-    return hashlib.pbkdf2_hmac("sha256", password_bytes, salt, iterations, dklen=32)
-
-def _pbkdf2_hash(password: str, salt_hex: str, iterations: int = 200_000) -> str:
-    salt = binascii.unhexlify(salt_hex)
-    dk = _pbkdf2_sha256(password.encode("utf-8"), salt, iterations)
-    return binascii.hexlify(dk).decode("ascii")
-
-def generate_password_hash(password: str, *, iterations: int = 200_000) -> Tuple[str, str]:
-    """Return (salt_hex, hash_hex) for provisioning users in secrets.toml."""
-    salt = os.urandom(16)
-    salt_hex = binascii.hexlify(salt).decode("ascii")
-    hash_hex = _pbkdf2_hash(password, salt_hex, iterations)
-    return salt_hex, hash_hex
-
-def verify_password(password: str, *, salt_hex: str, expected_hash_hex: str, iterations: int = 200_000) -> bool:
-    computed = _pbkdf2_hash(password, salt_hex, iterations)
-    return hmac.compare_digest(computed, expected_hash_hex)
+_LAST_EMAIL_KEY = "login__last_email"
+_FORM_KEY = "login_form"
 
 
-# ============================
-# Config & state
-# ============================
-@dataclass
-class AuthConfig:
-    min_password_len: int = 8
-    lockout_after: int = 5
-    lockout_minutes: int = 5
-
-@dataclass
-class UserRecord:
-    username: str
-    display_name: str
-    password_hash: str
-    salt: str
-
-@dataclass
-class StaticCreds:
-    username: str
-    password: str
-    display_name: str
-
-_DEF_TZ = timezone.utc
-
-def _now() -> datetime:
-    return datetime.now(tz=_DEF_TZ)
-
-def _read_auth_config() -> AuthConfig:
-    data = st.secrets.get("auth", {})
-    return AuthConfig(
-        min_password_len=int(data.get("min_password_len", 8)),
-        lockout_after=int(data.get("lockout_after", 5)),
-        lockout_minutes=int(data.get("lockout_minutes", 5)),
-    )
-
-def _read_user(username: str) -> Optional[UserRecord]:
-    users: Dict[str, Dict[str, str]] = st.secrets.get("users", {})  # type: ignore[assignment]
-    raw = users.get(username)
-    if not raw:
-        return None
-    return UserRecord(
-        username=username,
-        display_name=raw.get("display_name", username),
-        password_hash=raw.get("password_hash", ""),
-        salt=raw.get("salt", ""),
-    )
-
-def _read_static_creds() -> StaticCreds:
-    data = st.secrets.get("static", {})
-    return StaticCreds(
-        username=str(data.get("username", "Santeri")),
-        password=str(data.get("password", "Volotinen")),
-        display_name=str(data.get("display_name", "Santeri Volotinen")),
-    )
-
-def _ensure_auth_state() -> None:
-    st.session_state.setdefault(
-        "auth",
-        {"authenticated": False, "user": None, "attempts": 0, "lock_until": None},
-    )
-
-def _locked_until() -> Optional[datetime]:
-    return st.session_state.get("auth", {}).get("lock_until")
-
-def _register_failure(cfg: AuthConfig) -> None:
-    auth = st.session_state["auth"]
-    auth["attempts"] = int(auth.get("attempts", 0)) + 1
-    if auth["attempts"] >= cfg.lockout_after:
-        auth["lock_until"] = _now() + timedelta(minutes=cfg.lockout_minutes)
-        auth["attempts"] = 0
-
-def _clear_failures() -> None:
-    auth = st.session_state["auth"]
-    auth["attempts"] = 0
-    auth["lock_until"] = None
+def _ensure_auth_state() -> Dict[str, object]:
+    return st.session_state.setdefault("auth", {"authenticated": False, "user": None})
 
 
-# ============================
-# Public API
-# ============================
 def logout() -> None:
-    _ensure_auth_state()
-    auth = st.session_state["auth"]
-    auth["authenticated"] = False
-    auth["user"] = None
+    """Terminate the Supabase session and rerun the app."""
+    try:
+        supabase_sign_out()
+    except Exception as exc:  # pragma: no cover - defensive logging for UI usage
+        print(f"Supabase sign_out failed: {exc}")
+    st.rerun()
 
-def login(
-    title: str = "ScoutLens",
-    *,
-    dim_background: bool = False,
-    background_opacity: float = 1.0,
-) -> None:
-    """
-    Minimal, hardened username/password gate using Streamlit session_state.
 
-    Credentials:
-      [static]
-      username = "Santeri"
-      password = "Volotinen"
-      display_name = "Santeri Volotinen"
-
-      # Optional hashed users
-      [auth]
-      min_password_len = 8
-      lockout_after = 5
-      lockout_minutes = 5
-
-      [users.santeri]
-      display_name = "Santeri Volotinen"
-      salt = "<hex>"
-      password_hash = "<hex>"
-
-    - background_opacity: passed to set_login_background (1.0 = 100%).
-    - dim_background: add a radial scrim for contrast.
-    """
-    _ensure_auth_state()
-    if st.session_state["auth"].get("authenticated"):
-        return
-
-    cfg = _read_auth_config()
-    static_creds = _read_static_creds()
-
-    # Background & base styles
-    set_login_background("login_bg.png", opacity=background_opacity)
+def _inject_login_styles(opacity: float) -> None:
+    set_login_background("login_bg.png", opacity=opacity)
     st.markdown('<div class="sl-hero"></div>', unsafe_allow_html=True)
     st.markdown(
         """
@@ -184,32 +53,27 @@ def login(
           border: 1px solid rgba(255,255,255,.10);
           color: #f8fafc; border-radius: 12px;
         }
-        .stTextInput > label, .stCheckbox > label { color: #e2e8f0; }
-        .stCheckbox > div[role="checkbox"] { border-radius: 6px; }
+        .stTextInput > label { color: #e2e8f0; }
         .stButton button { border-radius: 12px; padding: 10px 14px; font-weight: 600; }
+        .login-caption { color: rgba(226, 232, 240, 0.8); font-size: var(--fs-14); margin-bottom: 12px; }
         </style>
         """,
         unsafe_allow_html=True,
     )
-
-    # Responsive overrides (Fold/tablet & phones)
     st.markdown(
         """
         <style>
         div[data-testid="stForm"] { max-width: clamp(340px, 36vw, 580px); }
-
         @media (min-width: 1200px) and (max-width: 2400px) and (min-aspect-ratio: 1/1.3) and (max-aspect-ratio: 5/4) {
           div[data-testid="stForm"] { max-width: 620px; padding: 28px 24px; border-radius: 16px; }
           .form-title { font-size: var(--fs-24); }
           .stTextInput > div > div > input { font-size: var(--fs-16); padding: 12px 14px; }
           .stButton button { font-size: var(--fs-16); padding: 12px 16px; border-radius: 14px; }
         }
-
         @media (max-width: 540px) {
           div[data-testid="stForm"] { max-width: 94vw; padding: 18px 16px; border-radius: 10px; }
           .form-title { font-size: var(--fs-16); }
         }
-
         @media (max-height: 520px) and (orientation: landscape) {
           .block-container { padding-top: 2vh !important; padding-bottom: 2vh !important; }
           div[data-testid="stForm"] { max-width: 520px; }
@@ -219,49 +83,84 @@ def login(
         unsafe_allow_html=True,
     )
 
-    lu = _locked_until()
-    if isinstance(lu, datetime) and lu > _now():
-        remaining = int((lu - _now()).total_seconds())
-        minutes, seconds = divmod(remaining, 60)
-        st.error(f"Too many attempts. Try again in {minutes} min {seconds} s.")
-        st.stop()
 
+def login(
+    title: str = "ScoutLens",
+    *,
+    dim_background: bool = False,
+    background_opacity: float = 1.0,
+) -> None:
+    """Render the authentication form when the user is not signed in."""
+
+    _ensure_auth_state()
+    client = get_client()
+    session = client.auth.get_session()
+    if session and getattr(session, "access_token", None):
+        return
+
+    _inject_login_styles(background_opacity)
     if dim_background:
         st.markdown('<div class="login-scrim"></div>', unsafe_allow_html=True)
 
-    with st.form("login_form", clear_on_submit=False):
+    auth_state = st.session_state.get("auth", {})
+    last_error = auth_state.pop("last_error", None)
+
+    with st.form(_FORM_KEY, clear_on_submit=False):
         st.markdown(f"<div class='form-title'>{title}</div>", unsafe_allow_html=True)
-        username = st.text_input("Username", autocomplete="username", placeholder="Enter your username")
-        password = st.text_input("Password", type="password", autocomplete="current-password", placeholder="Enter your password")
-        remember = st.checkbox("Keep me signed in (this session)", value=True)
+        st.markdown(
+            "<div class='login-caption'>Sign in with your Supabase email and password. Writes require authentication.</div>",
+            unsafe_allow_html=True,
+        )
+        default_email = st.session_state.get(_LAST_EMAIL_KEY, "")
+        email = st.text_input(
+            "Email",
+            value=default_email,
+            autocomplete="email",
+            placeholder="you@example.com",
+        )
+        password = st.text_input(
+            "Password",
+            type="password",
+            autocomplete="current-password",
+            placeholder="Enter your password",
+        )
         submitted = st.form_submit_button("Sign in", type="primary")
 
+    if last_error:
+        st.warning(last_error)
+
     if submitted:
-        if len(password) < cfg.min_password_len:
-            st.warning(f"Password must be at least {cfg.min_password_len} characters.")
+        email = email.strip()
+        st.session_state[_LAST_EMAIL_KEY] = email
+        if not email:
+            st.warning("Email is required.")
+            st.stop()
+        if not password:
+            st.warning("Password is required.")
+            st.stop()
+        try:
+            response = supabase_sign_in(email=email, password=password)
+        except AuthApiError as exc:
+            print(f"Supabase sign_in invalid credentials: {exc}")
+            st.error("Invalid email or password. Please try again.")
+            st.stop()
+        except AuthError as exc:
+            print(f"Supabase sign_in auth error: {exc}")
+            st.error("Authentication failed. Please try again in a moment.")
+            st.stop()
+        except Exception as exc:  # pragma: no cover - unexpected runtime failures
+            print(f"Supabase sign_in unexpected error: {exc}")
+            st.error("Unexpected error during sign in. Please retry.")
             st.stop()
 
-        authed: Optional[UserRecord] = None
-        static_creds = _read_static_creds()
-        if username == static_creds.username and password == static_creds.password:
-            authed = UserRecord(username=static_creds.username, display_name=static_creds.display_name, password_hash="", salt="")
-        else:
-            user = _read_user(username)
-            if user and user.salt and user.password_hash:
-                if verify_password(password, salt_hex=user.salt, expected_hash_hex=user.password_hash):
-                    authed = user
-
-        if not authed:
-            _register_failure(cfg)
-            st.error("Invalid username or password.")
+        session = getattr(response, "session", None)
+        if not session or not getattr(session, "access_token", None):
+            st.error("Supabase did not return a valid session. Please try again.")
             st.stop()
 
-        _clear_failures()
-        auth = st.session_state["auth"]
-        auth["authenticated"] = True
-        auth["user"] = {"username": authed.username, "name": authed.display_name}
-        if not remember:
-            auth["ephemeral"] = True
         st.rerun()
 
     st.stop()
+
+
+__all__ = ["login", "logout"]

--- a/app/supabase_client.py
+++ b/app/supabase_client.py
@@ -1,5 +1,148 @@
-"""Supabase client wrapper for ScoutLens."""
+"""Supabase client helpers for ScoutLens."""
 
-from app.utils.supa import get_client
+from __future__ import annotations
 
-__all__ = ["get_client"]
+from typing import Any, Dict, Optional
+
+import streamlit as st
+from supabase import AuthError
+
+from app.utils.supa import get_client as _get_cached_client
+
+__all__ = ["get_client", "sign_in", "sign_out"]
+
+_AUTH_STATE_KEY = "auth"
+_SESSION_STATE_KEY = "supabase_session"
+
+
+def _ensure_auth_state() -> Dict[str, Any]:
+    """Return the mutable auth state dict stored in Streamlit session state."""
+    auth = st.session_state.setdefault(_AUTH_STATE_KEY, {})
+    auth.setdefault("authenticated", False)
+    auth.setdefault("user", None)
+    return auth
+
+
+def _serialize_user(user: Any) -> Optional[Dict[str, Any]]:
+    """Convert Supabase user model objects to plain dictionaries."""
+    if user is None:
+        return None
+    if isinstance(user, dict):
+        return user
+    for attr in ("model_dump", "dict"):
+        method = getattr(user, attr, None)
+        if callable(method):
+            try:
+                data = method()
+            except TypeError:
+                data = method(exclude_none=True)  # type: ignore[arg-type]
+            if isinstance(data, dict):
+                return data
+    snapshot: Dict[str, Any] = {}
+    for attr in (
+        "id",
+        "email",
+        "app_metadata",
+        "user_metadata",
+        "role",
+        "aud",
+        "created_at",
+        "last_sign_in_at",
+    ):
+        if hasattr(user, attr):
+            value = getattr(user, attr)
+            if value is not None:
+                snapshot[attr] = value
+    if not snapshot:
+        snapshot["repr"] = repr(user)
+    return snapshot
+
+
+def _store_session(session: Any, user: Any | None = None) -> None:
+    """Persist access and refresh tokens plus user metadata in session state."""
+    access_token = getattr(session, "access_token", None)
+    refresh_token = getattr(session, "refresh_token", None)
+    session_data: Dict[str, str] = {}
+    if access_token:
+        session_data["access_token"] = access_token
+    if refresh_token:
+        session_data["refresh_token"] = refresh_token
+    if session_data:
+        st.session_state[_SESSION_STATE_KEY] = session_data
+    auth = _ensure_auth_state()
+    auth["authenticated"] = True
+    auth["user"] = _serialize_user(user or getattr(session, "user", None))
+    auth.pop("last_error", None)
+
+
+def _clear_session_state(reason: Optional[str] = None) -> None:
+    """Reset cached Supabase session data and auth flags."""
+    had_tokens = st.session_state.pop(_SESSION_STATE_KEY, None) is not None
+    auth = _ensure_auth_state()
+    auth["authenticated"] = False
+    auth["user"] = None
+    if reason and had_tokens:
+        auth["last_error"] = reason
+    else:
+        auth.pop("last_error", None)
+
+
+def _apply_saved_session(client) -> None:
+    """Sync Supabase client auth with tokens stored in session state."""
+    stored = st.session_state.get(_SESSION_STATE_KEY)
+    current = client.auth.get_session()
+    current_access = getattr(current, "access_token", None) if current else None
+
+    if stored:
+        access_token = stored.get("access_token")
+        refresh_token = stored.get("refresh_token")
+        if access_token and refresh_token and access_token != current_access:
+            try:
+                response = client.auth.set_session(access_token, refresh_token)
+            except AuthError as exc:
+                print(f"Supabase set_session failed: {exc}")
+                _clear_session_state("Your session expired. Please sign in again.")
+                return
+            session = getattr(response, "session", None)
+            user = getattr(response, "user", None)
+            if session and getattr(session, "access_token", None):
+                _store_session(session, user)
+                return
+
+    current = client.auth.get_session()
+    if current and getattr(current, "access_token", None):
+        _store_session(current, getattr(current, "user", None))
+        return
+
+    if stored:
+        _clear_session_state("Your session expired. Please sign in again.")
+    else:
+        _clear_session_state()
+
+
+def get_client():
+    """Return the shared Supabase client, restoring saved auth when present."""
+    client = _get_cached_client()
+    _apply_saved_session(client)
+    return client
+
+
+def sign_in(email: str, password: str):
+    """Authenticate with Supabase email/password and cache the session tokens."""
+    response = get_client().auth.sign_in_with_password({"email": email, "password": password})
+    session = getattr(response, "session", None)
+    user = getattr(response, "user", None)
+    if session and getattr(session, "access_token", None):
+        _store_session(session, user)
+    else:
+        _clear_session_state()
+    return response
+
+
+def sign_out() -> None:
+    """Sign out from Supabase and clear cached session tokens."""
+    client = get_client()
+    try:
+        client.auth.sign_out()
+    finally:
+        _clear_session_state()


### PR DESCRIPTION
## Summary
- add Supabase auth helpers that persist session tokens and reuse them for cached clients
- replace the legacy static login gate with a Supabase email/password form and friendly error messaging
- ensure logout clears Supabase state and reruns the app for a clean session

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cf997f71b88320a66938bca5bc6c16