### PR TITLE
Switch player and team flows to Supabase

### DIFF
--- a/app/app_paths.py
+++ b/app/app_paths.py
@@ -1,6 +1,6 @@
 # app_paths.py — yhtenäinen datapolku local/Cloud
 from pathlib import Path
-import os, json
+import os
 
 APP_NAME = "ScoutLens"
 CLOUD = os.getenv("SCOUTLENS_CLOUD", "0") == "1"
@@ -17,24 +17,12 @@ else:
 
 DATA_DIR.mkdir(parents=True, exist_ok=True)
 
+
 def file_path(name: str) -> Path:
     return DATA_DIR / name
 
-# Predefined file paths and directories
-PLAYERS_FP = file_path("players.json")
-MATCHES_FP = file_path("matches.json")
-SCOUT_REPORTS_FP = file_path("scout_reports.json")
-NOTES_FP = file_path("notes.json")
 
+# Player photos and export artefacts can still live locally, but the
+# primary data source (players, teams, matches, reports, notes) is Supabase.
 PLAYER_PHOTOS_DIR = DATA_DIR / "player_photos"
 PLAYER_PHOTOS_DIR.mkdir(parents=True, exist_ok=True)
-
-# Luo oletustiedostot jos puuttuu (turvallinen ajaa aina)
-for fp, default in [
-    (PLAYERS_FP, []),
-    (MATCHES_FP, []),
-    (SCOUT_REPORTS_FP, []),
-    (NOTES_FP, []),
-]:
-    if not fp.exists():
-        fp.write_text(json.dumps(default), encoding="utf-8")

--- a/app/data_manager.py
+++ b/app/data_manager.py
@@ -1,34 +1,79 @@
 import streamlit as st
 import pandas as pd
-import json
-from pathlib import Path
 from uuid import uuid4
-from app.storage import load_json, save_json
+from typing import Any, Dict, Iterable, List, Optional, Set
 
-from app.app_paths import file_path, DATA_DIR
+from postgrest.exceptions import APIError
+
+from app.supabase_client import get_client
 
 # yritetään käyttää list_teams(), mutta ei ole pakollinen
 try:
-    from app.data_utils import list_teams
-except Exception:
-    list_teams = None  # fallback players.jsonista
+    from app.data_utils import list_teams  # type: ignore
+except Exception:  # pragma: no cover - fallback mode
+    list_teams = None  # type: ignore
 
-PLAYERS_FP = file_path("players.json")
 
-# ---------- JSON apurit ----------
-def _load_players():
+_BASE_PLAYER_COLUMNS: Set[str] = {
+    "id",
+    "name",
+    "team_name",
+    "team_id",
+    "date_of_birth",
+    "nationality",
+    "preferred_foot",
+    "club_number",
+    "primary_position",
+    "secondary_positions",
+    "notes",
+    "tags",
+    "height",
+    "weight",
+    "position",
+    "scout_rating",
+    "transfermarkt_url",
+    "external_id",
+    "photo_path",
+}
+
+
+def _show_error(prefix: str, err: Exception) -> None:
+    msg = getattr(err, "message", str(err))
+    st.error(f"{prefix}: {msg}")
+
+
+def _load_players(team: Optional[str] = None) -> List[Dict[str, Any]]:
+    client = get_client()
+    if not client:
+        return []
+    query = client.table("players").select("*")
+    if team:
+        query = query.eq("team_name", team)
     try:
-        if PLAYERS_FP.exists():
-            return json.loads(PLAYERS_FP.read_text(encoding="utf-8"))
-    except Exception as e:
-        st.error(f"Failed to read players.json: {e}")
-    return []
+        res = query.execute()
+    except APIError as err:  # pragma: no cover - UI feedback
+        _show_error("Failed to load players from Supabase", err)
+        return []
+    return [dict(row) for row in (res.data or [])]
 
-def _save_players(players):
+
+def _fetch_team_record(team: str) -> Optional[Dict[str, Any]]:
+    client = get_client()
+    if not client or not team:
+        return None
     try:
-        PLAYERS_FP.write_text(json.dumps(players, ensure_ascii=False, indent=2), encoding="utf-8")
-    except Exception as e:
-        st.error(f"Failed to write players.json: {e}")
+        res = (
+            client.table("teams")
+            .select("id,name")
+            .eq("name", team)
+            .limit(1)
+            .execute()
+        )
+    except APIError as err:  # pragma: no cover - UI feedback
+        _show_error("Failed to resolve team in Supabase", err)
+        return None
+    rows = res.data or []
+    return dict(rows[0]) if rows else None
 
 def _norm_team(p: dict) -> str:
     return (
@@ -75,29 +120,93 @@ def _to_df(players_for_team: list) -> pd.DataFrame:
 
 def _clean_val(v):
     if pd.isna(v):
-        return ""
-    # pandas/np tyypit -> perus Python
+        return None
     if isinstance(v, pd.Timestamp):
         return v.isoformat()
     try:
         import numpy as np
+
         if isinstance(v, np.integer):
             return int(v)
         if isinstance(v, np.floating):
             return float(v)
-    except Exception:
+    except Exception:  # pragma: no cover - numpy optional in tests
         pass
+    if isinstance(v, str):
+        s = v.strip()
+        return s if s else None
     return v
+
+
+def _ensure_iterable(value) -> Optional[list]:
+    if value in (None, ""):
+        return None
+    if isinstance(value, str):
+        items = [item.strip() for item in value.split(",") if item.strip()]
+        return items or None
+    if isinstance(value, Iterable) and not isinstance(value, (bytes, str)):
+        cleaned = [str(item).strip() for item in value if str(item).strip()]
+        return cleaned or None
+    return None
+
+
+def _collect_allowed_columns(players_for_team: Iterable[Dict[str, Any]]) -> Set[str]:
+    cols = set(_BASE_PLAYER_COLUMNS)
+    for row in players_for_team:
+        cols.update(row.keys())
+    return cols
+
+
+def _prepare_payload(
+    row: Dict[str, Any],
+    *,
+    team: str,
+    allowed: Set[str],
+    team_id: Optional[str],
+) -> Dict[str, Any]:
+    payload: Dict[str, Any] = {}
+    # Include legacy uppercase keys when available
+    name = row.get("name") or row.get("Name") or ""
+    payload["name"] = str(name).strip()
+    payload["team_name"] = team
+    pid = (
+        str(row.get("id") or "").strip()
+        or str(row.get("PlayerID") or "").strip()
+    )
+    if not pid:
+        pid = uuid4().hex
+    payload["id"] = pid
+
+    if team_id:
+        payload.setdefault("team_id", team_id)
+
+    for col in allowed:
+        if col in ("id", "name", "team_name", "team_id"):
+            continue
+        if col in row:
+            cleaned = _clean_val(row[col])
+            if col in {"secondary_positions", "tags"}:
+                cleaned = _ensure_iterable(row[col])
+            if col in {"club_number", "height", "weight", "scout_rating"} and cleaned not in (None, ""):
+                try:
+                    cleaned = int(cleaned)
+                except Exception:
+                    cleaned = None
+            if cleaned is not None:
+                payload[col] = cleaned
+            else:
+                payload[col] = None
+    return payload
 
 # ---------- UI ----------
 def show_data_manager():
-    st.title("🛠️ ScoutLens Data Manager (JSON)")
+    st.title("🛠️ ScoutLens Data Manager (Supabase)")
+    st.caption("Edits sync directly with the Supabase `players` table.")
 
     # 1) Valitse joukkue
     team = st.session_state.get("selected_team")
     if not team:
-        # yritä ensin data_utils.list_teams(), muuten päättele players.jsonista
-        teams = []
+        teams: List[str] = []
         if callable(list_teams):
             try:
                 teams = list_teams() or []
@@ -108,17 +217,13 @@ def show_data_manager():
             teams = sorted({_norm_team(p) for p in all_players if _norm_team(p)})
         team = st.selectbox("Select a team to manage:", teams) if teams else None
         if team:
-            # Kirjoita stateen vain jos arvo muuttuu (vältetään turhat rerunit)
-            if team != st.session_state.get("selected_team"):
-                st.session_state["selected_team"] = team
+            st.session_state["selected_team"] = team
 
     if not team:
         st.warning("Please select a team to manage.")
         return
 
-    # 2) Lataa ja suodata joukkueen pelaajat
-    players_all = _load_players()
-    team_players = [p for p in players_all if _norm_team(p) == team]
+    team_players = _load_players(team)
     df = _to_df(team_players)
 
     st.subheader(f"Players for {team}")
@@ -129,32 +234,44 @@ def show_data_manager():
             num_rows="dynamic",
             use_container_width=True,
         )
-    except AttributeError:
+    except AttributeError:  # pragma: no cover - Streamlit fallback
         st.error("Editable data grid not available in this Streamlit version.")
         st.dataframe(df)
         return
 
-    # 3) Tallenna muutokset players.jsoniin (korvaa valitun joukkueen rivit)
+    allowed = _collect_allowed_columns(team_players)
+
     if st.button("Save Changes", key="dm_save_players", type="primary"):
+        client = get_client()
+        if not client:
+            st.error("Supabase client is not configured.")
+            return
+        team_row = _fetch_team_record(team)
+        team_id = team_row.get("id") if team_row else None
+
+        new_rows: List[Dict[str, Any]] = []
+        for _, row in edited.iterrows():
+            payload = _prepare_payload(row.to_dict(), team=team, allowed=allowed, team_id=team_id)
+            new_rows.append(payload)
+
+        existing_ids = {str(p.get("id")) for p in team_players if p.get("id")}
+        new_ids = {str(row.get("id")) for row in new_rows if row.get("id")}
+        removed_ids = [pid for pid in existing_ids - new_ids if pid]
+
         try:
-            kept = [p for p in players_all if _norm_team(p) != team]
-            new_rows = []
-            for _, row in edited.iterrows():
-                rec = {col: _clean_val(row[col]) for col in edited.columns}
-                # pakota minimit
-                if not rec.get("id"):
-                    rec["id"] = uuid4().hex
-                if "name" not in rec and "Name" in rec:
-                    rec["name"] = rec["Name"]
-                if not rec.get("team_name"):
-                    rec["team_name"] = team
-                new_rows.append(rec)
+            if removed_ids:
+                client.table("players").delete().in_("id", removed_ids).execute()
+            if new_rows:
+                try:
+                    client.table("players").upsert(new_rows, on_conflict="id").execute()
+                except TypeError:
+                    client.table("players").upsert(new_rows).execute()
+            st.cache_data.clear()
+            st.success(f"Player data for {team} saved to Supabase.")
+        except APIError as err:  # pragma: no cover - UI feedback
+            _show_error("Failed to save players", err)
+        except Exception as err:  # pragma: no cover - unexpected
+            st.error(f"Unexpected error saving players: {err}")
 
-            _save_players(kept + new_rows)
-            st.success(f"Player data for {team} saved to players.json!")
-        except Exception as e:
-            st.error(f"Error saving data: {e}")
-
-    # 4) Esikatselu
     st.markdown("### Preview Updated Data")
     st.dataframe(edited.reset_index(drop=True))

--- a/app/storage.py
+++ b/app/storage.py
@@ -1,7 +1,18 @@
-# app/storage.py — self-contained adapter (no app.* imports)
+# app/storage.py — Supabase-backed storage helpers with local export paths
 from __future__ import annotations
 from pathlib import Path
-import json, os, platform
+import os
+import platform
+from typing import Any, Dict, Iterable, List, Optional
+
+try:  # pragma: no cover - optional dependency for UI feedback
+    import streamlit as st
+except Exception:  # pragma: no cover
+    st = None  # type: ignore
+
+from postgrest.exceptions import APIError
+
+from app.supabase_client import get_client
 
 # --- Base dir: Windows -> %APPDATA%\ScoutLens, muut -> repo/.data
 def _default_base_dir() -> Path:
@@ -15,24 +26,78 @@ def _default_base_dir() -> Path:
 BASE_DIR = _default_base_dir()
 BASE_DIR.mkdir(parents=True, exist_ok=True)
 
+
 def file_path(name: str) -> Path:
     p = BASE_DIR / name
     p.parent.mkdir(parents=True, exist_ok=True)
     return p
 
+
+_TABLE_MAP = {
+    "players.json": "players",
+    "teams.json": "teams",
+    "matches.json": "matches",
+    "scout_reports.json": "reports",
+    "notes.json": "notes",
+}
+
+
+def _notify_error(msg: str) -> None:
+    if st is not None:
+        st.error(msg)
+    else:
+        print(msg)
+
+
+def _resolve_table(name_or_fp: str | Path) -> Optional[str]:
+    name = name_or_fp if isinstance(name_or_fp, str) else name_or_fp.name
+    return _TABLE_MAP.get(Path(name).name)
+
+
 def load_json(name_or_fp: str | Path, default):
-    p = file_path(name_or_fp) if isinstance(name_or_fp, str) else Path(name_or_fp)
+    table = _resolve_table(name_or_fp)
+    if not table:
+        return default
+    client = get_client()
+    if not client:
+        return default
     try:
-        if p.exists():
-            return json.loads(p.read_text(encoding="utf-8"))
-    except Exception:
-        pass
-    return default
+        res = client.table(table).select("*").execute()
+    except APIError as err:  # pragma: no cover - UI feedback
+        _notify_error(f"Failed to load {table}: {getattr(err, 'message', str(err))}")
+        return default
+    data = res.data or []
+    if isinstance(default, list):
+        return data
+    if isinstance(default, dict) and data:
+        # Reduce to first row when dict requested
+        return dict(data[0])
+    return data or default
+
 
 def save_json(name_or_fp: str | Path, data):
-    p = file_path(name_or_fp) if isinstance(name_or_fp, str) else Path(name_or_fp)
-    p.parent.mkdir(parents=True, exist_ok=True)
-    p.write_text(json.dumps(data, ensure_ascii=False, indent=2), encoding="utf-8")
+    table = _resolve_table(name_or_fp)
+    if not table or data is None:
+        return
+    client = get_client()
+    if not client:
+        return
+    rows: List[Dict[str, Any]]
+    if isinstance(data, dict):
+        rows = [data]
+    elif isinstance(data, Iterable):
+        rows = [r for r in data if isinstance(r, dict)]
+    else:
+        rows = []
+    if not rows:
+        return
+    try:
+        try:
+            client.table(table).upsert(rows).execute()
+        except TypeError:
+            client.table(table).upsert(rows, on_conflict="id").execute()
+    except APIError as err:  # pragma: no cover - surface error but keep running
+        _notify_error(f"Failed to save {table}: {getattr(err, 'message', str(err))}")
 
 IS_CLOUD = (platform.system() not in ("Windows", "Darwin"))
 
@@ -45,34 +110,12 @@ class Storage:
     def file_path(self, name: str) -> Path:
         return self.base_dir / name
 
-    def read_json(self, fp: Path, default):
-        try:
-            if fp.exists():
-                return json.loads(fp.read_text(encoding="utf-8"))
-        except Exception:
-            pass
-        return default
-
-    def write_json(self, fp: Path, data):
-        fp.parent.mkdir(parents=True, exist_ok=True)
-        fp.write_text(json.dumps(data, ensure_ascii=False, indent=2), encoding="utf-8")
-
     # -----------------------------------------------------
     # Player helpers
     # -----------------------------------------------------
-    def _players_fp(self) -> Path:
-        """Return path to the JSON file storing players."""
-        return self.file_path("players.json")
-
-    def _load_players(self) -> list[dict]:
-        return self.read_json(self._players_fp(), [])
-
-    def _save_players(self, players: list[dict]):
-        self.write_json(self._players_fp(), players)
-
     def list_players(self) -> list[dict]:
-        """Return all players stored on disk."""
-        return self._load_players()
+        """Return all players stored in Supabase."""
+        return load_json("players.json", [])
 
     def upsert_player(self, player: dict) -> str:
         """Insert or update a player record.
@@ -82,47 +125,65 @@ class Storage:
         replaced while keeping any unspecified fields intact. Returns the
         player's id.
         """
-        players = self._load_players()
+        from uuid import uuid4
+
         pid = str(player.get("id") or "").strip()
         if not pid:
-            from uuid import uuid4
-
             pid = uuid4().hex
             player["id"] = pid
 
-        replaced = False
-        for idx, existing in enumerate(players):
-            if str(existing.get("id")) == pid:
-                players[idx] = {**existing, **player}
-                replaced = True
-                break
-        if not replaced:
-            players.append(player)
+        client = get_client()
+        if not client:
+            raise RuntimeError("Supabase client is not configured")
 
-        self._save_players(players)
+        try:
+            try:
+                client.table("players").upsert(player, on_conflict="id").execute()
+            except TypeError:
+                client.table("players").upsert(player).execute()
+        except APIError as err:
+            _notify_error(f"Failed to upsert player: {getattr(err, 'message', str(err))}")
+            raise
+
+        if st is not None:
+            st.cache_data.clear()
         return pid
 
     def remove_by_ids(self, ids: list[str]) -> int:
         """Remove players whose id is in ``ids``. Returns number of removed."""
-        ids_set = {str(i) for i in ids}
-        players = self._load_players()
-        new_players = [p for p in players if str(p.get("id")) not in ids_set]
-        removed = len(players) - len(new_players)
-        if removed:
-            self._save_players(new_players)
-        return removed
+        ids_clean = [str(i) for i in ids if i]
+        if not ids_clean:
+            return 0
+        client = get_client()
+        if not client:
+            return 0
+        # Fetch count before deletion for accurate return value
+        existing = load_json("players.json", [])
+        existing_ids = {str(p.get("id")) for p in existing}
+        to_remove = [pid for pid in ids_clean if pid in existing_ids]
+        if not to_remove:
+            return 0
+        try:
+            client.table("players").delete().in_("id", to_remove).execute()
+        except APIError as err:
+            _notify_error(f"Failed to delete players: {getattr(err, 'message', str(err))}")
+            return 0
+        if st is not None:
+            st.cache_data.clear()
+        return len(to_remove)
 
     def _update_field(self, player_id: str, field: str, value) -> bool:
-        players = self._load_players()
-        updated = False
-        for p in players:
-            if str(p.get("id")) == str(player_id):
-                p[field] = value
-                updated = True
-                break
-        if updated:
-            self._save_players(players)
-        return updated
+        client = get_client()
+        if not client:
+            return False
+        try:
+            client.table("players").update({field: value}).eq("id", player_id).execute()
+        except APIError as err:
+            _notify_error(f"Failed to update player: {getattr(err, 'message', str(err))}")
+            return False
+        if st is not None:
+            st.cache_data.clear()
+        return True
 
     def set_photo_path(self, player_id: str, path: str) -> bool:
         """Persist photo path for the given player."""


### PR DESCRIPTION
## Summary
- replace local JSON helpers in the data manager and add-player form with Supabase reads and writes
- back the teams_store shim and storage adapter with Supabase tables and remove JSON file creation
- refresh UI copy to reference Supabase as the data source and clear caches after writes

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cf9981df508320990b3b768151cb9c