### PR TITLE
Fix Supabase login for dict-based sessions

### DIFF
--- a/app/login.py
+++ b/app/login.py
@@ -7,7 +7,12 @@ from typing import Dict
 import streamlit as st
 from supabase import AuthApiError, AuthError
 
-from app.supabase_client import get_client, sign_in as supabase_sign_in, sign_out as supabase_sign_out
+from app.supabase_client import (
+    get_client,
+    session_value,
+    sign_in as supabase_sign_in,
+    sign_out as supabase_sign_out,
+)
 from app.ui import bootstrap_sidebar_auto_collapse
 from app.ui.login_bg import set_login_background
 
@@ -95,7 +100,7 @@ def login(
     _ensure_auth_state()
     client = get_client()
     session = client.auth.get_session()
-    if session and getattr(session, "access_token", None):
+    if session and session_value(session, "access_token"):
         return
 
     _inject_login_styles(background_opacity)
@@ -154,7 +159,7 @@ def login(
             st.stop()
 
         session = getattr(response, "session", None)
-        if not session or not getattr(session, "access_token", None):
+        if not session or not session_value(session, "access_token"):
             st.error("Supabase did not return a valid session. Please try again.")
             st.stop()
 

--- a/app/sync_utils.py
+++ b/app/sync_utils.py
@@ -3,7 +3,7 @@ import json
 from pathlib import Path
 from typing import Any
 
-from app.supabase_client import get_client
+from app.supabase_client import get_client, session_value
 
 
 def _ensure_authenticated_session(client: Any) -> None:
@@ -19,7 +19,7 @@ def _ensure_authenticated_session(client: Any) -> None:
     else:  # pragma: no cover - defensive for older client versions
         session = getattr(auth, "session", None)
 
-    if not session or getattr(session, "access_token", None) in (None, ""):
+    if not session or session_value(session, "access_token") in (None, ""):
         raise PermissionError("Supabase session missing. Sign in before syncing.")
 
 


### PR DESCRIPTION
## Summary
- add a shared session_value helper so Supabase auth tokens are captured even when sessions are dict-like
- update the login gate to accept dict-based Supabase sessions and keep reruns authenticated
- ensure sync utilities validate authenticated sessions using the same helper

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cf9ceeb50c83209f578d200c86b8a8