### PR TITLE
Adjust sidebar layout to prevent extra scrollbar

### DIFF
--- a/app/styles/sidebar.css
+++ b/app/styles/sidebar.css
@@ -32,14 +32,14 @@ section[data-testid="stSidebar"] .block-container {
   display: flex;
   flex-direction: column;
   gap: 1.5rem;
-  min-height: 100vh;
+  min-height: calc(100vh - 3.25rem);
 }
 
 .sidebar-shell {
   display: flex;
   flex-direction: column;
   gap: 1.5rem;
-  min-height: calc(100vh - 3rem);
+  min-height: 100%;
 }
 
 .sidebar-header {


### PR DESCRIPTION
## Summary
- adjust the sidebar block container height calculation to account for padding
- let the sidebar shell inherit the remaining vertical space to keep footer alignment

## Testing
- not run (UI-only change)


------
https://chatgpt.com/codex/tasks/task_e_68cf9cc923f0832081b339ccfb109a89