### PR TITLE
Adjust sidebar padding to align logo

### DIFF
--- a/app/styles/sidebar.css
+++ b/app/styles/sidebar.css
@@ -28,7 +28,7 @@ section[data-testid="stSidebar"][aria-expanded="false"] > div:first-child {
 }
 
 section[data-testid="stSidebar"] .block-container {
-  padding: 1.5rem 1.25rem 1.75rem;
+  padding: 0 1.25rem 1.75rem;
   display: flex;
   flex-direction: column;
   gap: 1.5rem;
@@ -311,7 +311,7 @@ section[data-testid="stSidebar"] .sidebar-signout button:active {
   }
 
   section[data-testid="stSidebar"] .block-container {
-    padding: 1.25rem 1rem 1.5rem;
+    padding: 0 1rem 1.5rem;
   }
 }
 


### PR DESCRIPTION
## Summary
- reduce the top padding on the sidebar block container so the layout starts at the top edge
- mirror the padding adjustment for the mobile breakpoint to keep spacing consistent

## Testing
- not run (CSS-only change)


------
https://chatgpt.com/codex/tasks/task_e_68cfd196dbe88320baf100de886b1398