### PR TITLE
codex: centralize sidebar handling and guard usage

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,9 @@
+repos:
+  - repo: local
+    hooks:
+      - id: no-sidebar-outside-sidebar-module
+        name: Prevent stray st.sidebar usage
+        entry: tools/no_sidebar_outside_hook.py
+        language: system
+        types: [python]
+        pass_filenames: false

--- a/app/age_minutes.py
+++ b/app/age_minutes.py
@@ -1,89 +1,118 @@
-import streamlit as st
+from __future__ import annotations
+
 import pandas as pd
-from app.data_utils import load_data, save_data, validate_player_input, list_teams
+import streamlit as st
+
+from app.data_utils import list_teams, load_data, save_data, validate_player_input
 from app.metrics import add_minutes_per_match, calculate_summary
 from app.visuals import create_minutes_age_plot
 
-def show_age_minutes():
-    st.sidebar.header("⚽ Team Selection")
-    existing_teams = list_teams()
-    selected_team = st.sidebar.selectbox("Select Team", options=existing_teams + ["Create new team..."])
 
-    if selected_team == "Create new team...":
-        new_team = st.sidebar.text_input("New team name")
-        if st.sidebar.button("Create Team", type="primary"):
-            if new_team.strip():
-                selected_team = new_team.strip()
-                st.session_state["selected_team"] = selected_team
-                st.sidebar.success(f"Team '{selected_team}' created!")
-            else:
-                st.sidebar.error("Team name cannot be empty")
-    else:
-        st.session_state["selected_team"] = selected_team
+def show_age_minutes() -> None:
+    controls_col, content_col = st.columns([1, 3], gap="large")
 
-    if "selected_team" not in st.session_state:
-        st.warning("Please select or create a team to continue.")
-        st.stop()
+    with controls_col:
+        st.markdown("### ⚽ Team Selection")
+        existing_teams = list_teams()
+        team_options = existing_teams + ["Create new team..."]
+        selected_team = st.selectbox(
+            "Select Team",
+            options=team_options,
+            key="age_minutes_team_select",
+        )
 
-    team_name = st.session_state["selected_team"]
-    df = load_data(team_name)
-    df = add_minutes_per_match(df)
+        if selected_team == "Create new team...":
+            new_team = st.text_input("New team name", key="age_minutes_new_team")
+            if st.button("Create Team", type="primary", key="age_minutes_create_team"):
+                if new_team.strip():
+                    selected_team = new_team.strip()
+                    st.session_state["selected_team"] = selected_team
+                    st.success(f"Team '{selected_team}' created!")
+                else:
+                    st.error("Team name cannot be empty")
+        elif selected_team:
+            st.session_state["selected_team"] = selected_team
 
-    st.sidebar.header("Add or Update Player")
-    with st.sidebar.form("player_form"):
-        name = st.text_input("Name")
-        age = st.number_input("Age", min_value=15, max_value=45)
-        position = st.text_input("Position")
-        nationality = st.text_input("Nationality")
-        contract_start = st.date_input("Contract Start")
-        contract_end = st.date_input("Contract End")
-        loan = st.checkbox("On Loan")
-        minutes = st.number_input("Minutes Played", min_value=0)
-        matches = st.number_input("Matches Played", min_value=0)
-        submitted = st.form_submit_button("Add / Update Player", type="primary")
+        if "selected_team" not in st.session_state:
+            st.warning("Please select or create a team to continue.")
+            st.stop()
 
-        if submitted:
-            is_valid, msg = validate_player_input(name, df)
-            if is_valid:
-                df = df[df["Name"] != name]
-                new_row = pd.DataFrame([{ 
-                    "Name": name.title(),
-                    "Age": age,
-                    "Position": position,
-                    "Nationality": nationality,
-                    "ContractStart": contract_start,
-                    "ContractEnd": contract_end,
-                    "Loan": loan,
-                    "Minutes": minutes,
-                    "Matches": matches
-                }])
-                df = pd.concat([df, new_row], ignore_index=True)
-                save_data(df, team_name)
-                st.success(f"Player '{name}' added/updated!")
-            else:
-                st.error(msg)
+        team_name = st.session_state["selected_team"]
+        df = load_data(team_name)
+        df = add_minutes_per_match(df)
 
-    df_sorted = df.sort_values("Name")
-    st.sidebar.header("Remove Player")
-    remove_name = st.sidebar.selectbox("Select player to remove", options=["-"] + df_sorted["Name"].tolist())
-    if st.sidebar.button("Remove", type="secondary") and remove_name != "-":
-        df = df[df["Name"] != remove_name]
-        save_data(df, team_name)
-        st.sidebar.success(f"Removed player: {remove_name}")
+        st.markdown("### Add or Update Player")
+        with st.form("player_form"):
+            name = st.text_input("Name", key="age_minutes_player_name")
+            age = st.number_input("Age", min_value=15, max_value=45, key="age_minutes_age")
+            position = st.text_input("Position", key="age_minutes_position")
+            nationality = st.text_input("Nationality", key="age_minutes_nationality")
+            contract_start = st.date_input("Contract Start", key="age_minutes_contract_start")
+            contract_end = st.date_input("Contract End", key="age_minutes_contract_end")
+            loan = st.checkbox("On Loan", key="age_minutes_loan")
+            minutes = st.number_input("Minutes Played", min_value=0, key="age_minutes_minutes")
+            matches = st.number_input("Matches Played", min_value=0, key="age_minutes_matches")
+            submitted = st.form_submit_button("Add / Update Player", type="primary")
 
-    st.subheader(f"📊 Summary for team: {team_name}")
-    metrics = calculate_summary(df)
-    col1, col2, col3, col4 = st.columns(4)
-    col1.metric("Average Age", metrics["avg_age"])
-    col2.metric("Avg. Minutes", metrics["avg_minutes"])
-    col3.metric("Total Matches", metrics["total_matches"])
-    col4.metric("Minutes/Match", metrics["avg_minutes_per_match"])
+            if submitted:
+                is_valid, msg = validate_player_input(name, df)
+                if is_valid:
+                    df = df[df["Name"] != name]
+                    new_row = pd.DataFrame(
+                        [
+                            {
+                                "Name": name.title(),
+                                "Age": age,
+                                "Position": position,
+                                "Nationality": nationality,
+                                "ContractStart": contract_start,
+                                "ContractEnd": contract_end,
+                                "Loan": loan,
+                                "Minutes": minutes,
+                                "Matches": matches,
+                            }
+                        ]
+                    )
+                    df = pd.concat([df, new_row], ignore_index=True)
+                    save_data(df, team_name)
+                    st.success(f"Player '{name}' added/updated!")
+                else:
+                    st.error(msg)
 
-    df = df.copy()
-    df["ContractStart"] = pd.to_datetime(df["ContractStart"], errors="coerce")
-    df["ContractEnd"] = pd.to_datetime(df["ContractEnd"], errors="coerce")
-    fig = create_minutes_age_plot(df)
-    st.plotly_chart(fig, use_container_width=True)
+        df_sorted = df.sort_values("Name")
+        st.markdown("### Remove Player")
+        remove_name = st.selectbox(
+            "Select player to remove",
+            options=["-"] + df_sorted["Name"].tolist(),
+            key="age_minutes_remove_name",
+        )
+        if st.button("Remove", type="secondary", key="age_minutes_remove") and remove_name != "-":
+            df = df[df["Name"] != remove_name]
+            save_data(df, team_name)
+            st.success(f"Removed player: {remove_name}")
 
-    with st.expander("📋 View Raw Player Data"):
-        st.dataframe(df.reset_index(drop=True))
+    with content_col:
+        team_name = st.session_state.get("selected_team")
+        if not team_name:
+            st.info("Select a team to view metrics.")
+            return
+
+        st.subheader(f"📊 Summary for team: {team_name}")
+        df = load_data(team_name)
+        df = add_minutes_per_match(df)
+
+        metrics = calculate_summary(df)
+        col1, col2, col3, col4 = st.columns(4)
+        col1.metric("Average Age", metrics["avg_age"])
+        col2.metric("Avg. Minutes", metrics["avg_minutes"])
+        col3.metric("Total Matches", metrics["total_matches"])
+        col4.metric("Minutes/Match", metrics["avg_minutes_per_match"])
+
+        df = df.copy()
+        df["ContractStart"] = pd.to_datetime(df["ContractStart"], errors="coerce")
+        df["ContractEnd"] = pd.to_datetime(df["ContractEnd"], errors="coerce")
+        fig = create_minutes_age_plot(df)
+        st.plotly_chart(fig, use_container_width=True)
+
+        with st.expander("📋 View Raw Player Data"):
+            st.dataframe(df.reset_index(drop=True))

--- a/tools/no_sidebar_outside_hook.py
+++ b/tools/no_sidebar_outside_hook.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""Pre-commit hook to block direct ``st.sidebar`` usage outside the sidebar module."""
+
+from __future__ import annotations
+
+import ast
+import subprocess
+import sys
+from pathlib import Path
+from typing import Iterable, List, Sequence
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+ALLOWED_FILES = {REPO_ROOT / "app" / "ui" / "sidebar.py"}
+
+
+def _resolve_paths(args: Sequence[str]) -> List[Path]:
+    if args:
+        resolved: List[Path] = []
+        for raw in args:
+            candidate = Path(raw)
+            if not candidate.is_absolute():
+                candidate = REPO_ROOT / candidate
+            if candidate.exists():
+                resolved.append(candidate)
+        return resolved
+
+    result = subprocess.run(
+        ["git", "ls-files", "*.py"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return [REPO_ROOT / Path(line.strip()) for line in result.stdout.splitlines() if line.strip()]
+
+
+def _find_violations(paths: Iterable[Path]) -> List[str]:
+    violations: List[str] = []
+    for path in paths:
+        if path in ALLOWED_FILES:
+            continue
+        if not path.exists() or path.is_dir():
+            continue
+        try:
+            text = path.read_text(encoding="utf-8")
+        except UnicodeDecodeError:
+            continue
+
+        try:
+            tree = ast.parse(text, filename=str(path))
+        except SyntaxError:
+            continue
+
+        lines: List[str] = text.splitlines()
+        matches: List[str] = []
+
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Attribute):
+                if (
+                    isinstance(node.value, ast.Name)
+                    and node.value.id == "st"
+                    and node.attr == "sidebar"
+                ):
+                    lineno = getattr(node, "lineno", None)
+                    if lineno is None:
+                        continue
+                    source_line = lines[lineno - 1].strip() if lineno - 1 < len(lines) else ""
+                    matches.append(f"  line {lineno}: {source_line}")
+
+        if matches:
+            rel_path = path.relative_to(REPO_ROOT)
+            violations.append(f"{rel_path}:\n" + "\n".join(matches))
+    return violations
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = list(argv or sys.argv[1:])
+    paths = _resolve_paths(args)
+    violations = _find_violations(paths)
+    if violations:
+        message = [
+            "Direct st.sidebar usage is restricted to app/ui/sidebar.py.",
+            "Update your code to use the centralized sidebar API.",
+            "Violations detected:",
+            *violations,
+        ]
+        print("\n".join(message), file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/sidebar_debug_guard.py
+++ b/tools/sidebar_debug_guard.py
@@ -1,0 +1,111 @@
+"""Runtime helper to detect sidebar usage outside the dedicated module."""
+
+from __future__ import annotations
+
+import inspect
+from pathlib import Path
+from typing import Callable, Iterable, Optional
+
+import streamlit as st
+
+_DEFAULT_ALLOWED = (Path(__file__).resolve().parents[1] / "app" / "ui" / "sidebar.py",)
+
+
+class SidebarDebugGuard:
+    """Wraps ``st.sidebar`` and reports calls made from disallowed files."""
+
+    def __init__(
+        self,
+        *,
+        allowed_paths: Optional[Iterable[Path]] = None,
+        strict: bool = False,
+        reporter: Optional[Callable[[str], None]] = None,
+    ) -> None:
+        self._original = getattr(st, "sidebar")
+        self._allowed = {
+            Path(p).resolve()
+            for p in (allowed_paths if allowed_paths is not None else _DEFAULT_ALLOWED)
+        }
+        self._strict = strict
+        self._reporter = reporter or self._default_reporter
+        self._installed = False
+
+    # ------------------------------------------------------------------
+    def activate(self) -> None:
+        """Replace ``st.sidebar`` with this guard instance."""
+
+        if self._installed:
+            return
+        setattr(st, "sidebar", self)
+        self._installed = True
+
+    def deactivate(self) -> None:
+        """Restore the original ``st.sidebar`` object."""
+
+        if not self._installed:
+            return
+        setattr(st, "sidebar", self._original)
+        self._installed = False
+
+    def __enter__(self) -> "SidebarDebugGuard":  # pragma: no cover - dev helper
+        self.activate()
+        return self
+
+    def __exit__(self, *exc: object) -> None:  # pragma: no cover - dev helper
+        self.deactivate()
+
+    # ------------------------------------------------------------------
+    def __getattr__(self, name: str):
+        target = getattr(self._original, name)
+        if callable(target):
+            def wrapped(*args, **kwargs):
+                violation = self._check_callsite(name)
+                if violation is not None:
+                    if self._strict:
+                        raise RuntimeError(violation)
+                    self._reporter(violation)
+                return target(*args, **kwargs)
+
+            wrapped.__name__ = getattr(target, "__name__", name)
+            wrapped.__doc__ = getattr(target, "__doc__")
+            return wrapped
+        return target
+
+    # ------------------------------------------------------------------
+    def _check_callsite(self, name: str) -> str | None:
+        stack = inspect.stack()[2:]  # skip wrapper frames
+        caller = None
+        for frame_info in stack:
+            path = Path(frame_info.filename).resolve()
+            if path in self._allowed:
+                return None
+            if caller is None:
+                caller = frame_info
+
+        location = "<unknown>"
+        if caller and caller.filename:
+            path = Path(caller.filename).resolve()
+            location = f"{path}:{caller.lineno}"
+        allowed = ", ".join(str(p) for p in sorted(self._allowed))
+        return (
+            f"st.sidebar.{name} was called from {location}.\n"
+            f"Allowed sidebar writers: {allowed}"
+        )
+
+    @staticmethod
+    def _default_reporter(message: str) -> None:
+        try:
+            st.warning(message)
+        except Exception:
+            print(message)
+
+
+def install_sidebar_debug_guard(*, strict: bool = False) -> SidebarDebugGuard:
+    """Install the sidebar debug guard and return it for optional teardown."""
+
+    guard = SidebarDebugGuard(strict=strict)
+    guard.activate()
+    return guard
+
+
+__all__ = ["SidebarDebugGuard", "install_sidebar_debug_guard"]


### PR DESCRIPTION
## Summary
- tighten the Streamlit sidebar renderer so header/navigation wrappers stay singular and alerts relocate below the footer
- move the legacy age_minutes inputs into a main-column control panel to keep sidebar ownership centralized
- add an AST-based pre-commit hook plus optional runtime guard to block `st.sidebar` calls outside app/ui/sidebar.py

## Testing
- python tools/no_sidebar_outside_hook.py

------
https://chatgpt.com/codex/tasks/task_e_68d003141f7c83208a1353f638cb05c5