### PR TITLE
Fix sidebar font fallback

### DIFF
--- a/app/styles/sidebar.css
+++ b/app/styles/sidebar.css
@@ -4,7 +4,7 @@
 section[data-testid="stSidebar"] {
   background: radial-gradient(circle at 20% 0%, rgba(46, 67, 110, 0.68) 0%, rgba(17, 24, 39, 0.96) 58%, rgba(9, 12, 24, 0.98) 100%), #0b1526;
   color: #f4f7ff;
-  font-family: "Inter", "Font Awesome 6 Free", "Font Awesome 6 Brands", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
   min-width: 300px;
   max-width: 320px;
   border-right: 1px solid rgba(255, 255, 255, 0.04);


### PR DESCRIPTION
## Summary
- prevent the sidebar from falling back to icon fonts by limiting its default font stack to Inter and common system fonts

## Testing
- not run (UI-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d01d509cec8320b93afba7115b570d