### PR TITLE
Flatten sidebar markup to remove redundant containers and show nav icons

### DIFF
--- a/app/styles/sidebar.css
+++ b/app/styles/sidebar.css
@@ -2,7 +2,8 @@
 @import url("https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css");
 
 section[data-testid="stSidebar"] {
-  background: radial-gradient(circle at 20% 0%, rgba(46, 67, 110, 0.68) 0%, rgba(17, 24, 39, 0.96) 58%, rgba(9, 12, 24, 0.98) 100%), #0b1526;
+  background: radial-gradient(circle at 20% 0%, rgba(46, 67, 110, 0.68) 0%, rgba(17, 24, 39, 0.96) 58%, rgba(9, 12, 24, 0.98) 100%),
+    #0b1526;
   color: #f4f7ff;
   font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
   min-width: 300px;
@@ -35,14 +36,7 @@ section[data-testid="stSidebar"] .block-container {
   min-height: calc(100vh - 3.25rem);
 }
 
-.sidebar-shell {
-  display: flex;
-  flex-direction: column;
-  gap: 1.5rem;
-  min-height: 100%;
-}
-
-.sidebar-header {
+.sb-header-card {
   display: flex;
   flex-direction: column;
   gap: 1rem;
@@ -54,19 +48,25 @@ section[data-testid="stSidebar"] .block-container {
   backdrop-filter: blur(14px);
 }
 
-.sidebar-logo img {
+.sb-logo {
+  display: flex;
+  justify-content: center;
+}
+
+.sb-logo img {
   width: 100%;
   border-radius: 18px;
   box-shadow: 0 22px 38px rgba(12, 20, 44, 0.45);
 }
 
-.sidebar-title {
+.sb-title-block {
   display: flex;
   flex-direction: column;
   gap: 0.25rem;
+  text-align: center;
 }
 
-.scout-brand {
+.sb-title {
   font-size: 1.45rem;
   font-weight: 700;
   letter-spacing: 0.06em;
@@ -75,13 +75,21 @@ section[data-testid="stSidebar"] .block-container {
   text-shadow: 0 10px 25px rgba(10, 14, 28, 0.6);
 }
 
-.scout-sub {
+.sb-tagline {
   font-size: 0.95rem;
   color: rgba(230, 237, 255, 0.75);
   font-weight: 500;
 }
 
-.sidebar-nav {
+.sb-nav-title {
+  text-transform: uppercase;
+  font-size: 0.75rem;
+  letter-spacing: 0.32em;
+  font-weight: 600;
+  color: rgba(226, 234, 255, 0.55);
+}
+
+section[data-testid="stSidebar"] div[data-testid="stRadio"] {
   flex: 1 1 auto;
   display: flex;
   flex-direction: column;
@@ -92,14 +100,6 @@ section[data-testid="stSidebar"] .block-container {
   background: rgba(15, 21, 36, 0.72);
   box-shadow: 0 24px 45px rgba(7, 11, 24, 0.32);
   backdrop-filter: blur(18px);
-}
-
-.nav-title {
-  text-transform: uppercase;
-  font-size: 0.75rem;
-  letter-spacing: 0.32em;
-  font-weight: 600;
-  color: rgba(226, 234, 255, 0.55);
 }
 
 section[data-testid="stSidebar"] [role="radiogroup"] {
@@ -128,8 +128,7 @@ section[data-testid="stSidebar"] [role="radiogroup"] > label {
   overflow: hidden;
 }
 
-section[data-testid="stSidebar"] [role="radiogroup"] > label::before {
-  content: attr(data-icon);
+section[data-testid="stSidebar"] [role="radiogroup"] > label .sb-nav-icon {
   position: absolute;
   left: 1.15rem;
   top: 50%;
@@ -139,6 +138,7 @@ section[data-testid="stSidebar"] [role="radiogroup"] > label::before {
   font-size: 1.05rem;
   color: rgba(218, 225, 255, 0.7);
   transition: color 0.25s ease, transform 0.25s ease;
+  pointer-events: none;
 }
 
 section[data-testid="stSidebar"] [role="radiogroup"] > label:hover {
@@ -149,7 +149,7 @@ section[data-testid="stSidebar"] [role="radiogroup"] > label:hover {
   box-shadow: 0 16px 30px rgba(16, 28, 66, 0.35);
 }
 
-section[data-testid="stSidebar"] [role="radiogroup"] > label:hover::before {
+section[data-testid="stSidebar"] [role="radiogroup"] > label:hover .sb-nav-icon {
   color: rgba(250, 253, 255, 0.85);
   transform: translateY(-50%) scale(1.08);
 }
@@ -161,7 +161,7 @@ section[data-testid="stSidebar"] [role="radiogroup"] > label:has(input:checked) 
   box-shadow: 0 18px 40px rgba(18, 35, 76, 0.55), inset 0 0 0 1px rgba(255, 255, 255, 0.22);
 }
 
-section[data-testid="stSidebar"] [role="radiogroup"] > label:has(input:checked)::before {
+section[data-testid="stSidebar"] [role="radiogroup"] > label:has(input:checked) .sb-nav-icon {
   color: #ffffff;
   transform: translateY(-50%) scale(1.12);
 }
@@ -189,7 +189,7 @@ section[data-testid="stSidebar"] a:hover {
   color: #ffffff;
 }
 
-.sidebar-profile-card {
+.sb-profile-card {
   display: flex;
   align-items: center;
   gap: 0.85rem;
@@ -199,9 +199,10 @@ section[data-testid="stSidebar"] a:hover {
   border: 1px solid rgba(255, 255, 255, 0.07);
   background: rgba(18, 24, 40, 0.78);
   box-shadow: 0 20px 35px rgba(7, 12, 26, 0.38);
+  backdrop-filter: blur(14px);
 }
 
-.profile-avatar {
+.sb-profile-avatar {
   width: 46px;
   height: 46px;
   border-radius: 50%;
@@ -218,15 +219,15 @@ section[data-testid="stSidebar"] a:hover {
   overflow: hidden;
 }
 
-.profile-avatar::after {
+.sb-profile-avatar::after {
   content: attr(data-initials);
 }
 
-.profile-avatar.has-image::after {
+.sb-profile-avatar.has-image::after {
   content: "";
 }
 
-.profile-avatar img {
+.sb-profile-avatar img {
   width: 100%;
   height: 100%;
   object-fit: cover;
@@ -234,28 +235,29 @@ section[data-testid="stSidebar"] a:hover {
   display: block;
 }
 
-.profile-meta {
+.sb-profile-meta {
   display: flex;
   flex-direction: column;
   gap: 0.2rem;
 }
 
-.profile-name {
+.sb-profile-name {
   font-weight: 600;
   color: #f9fbff;
 }
 
-.profile-email {
+.sb-profile-email {
   font-size: 0.8rem;
   color: rgba(222, 229, 255, 0.65);
 }
 
-.sidebar-signout {
+section[data-testid="stSidebar"] div[data-testid="stButton"] {
+  width: 100%;
   margin-top: 0.75rem;
 }
 
-section[data-testid="stSidebar"] .sidebar-signout div[data-testid="baseButton-secondary"] > button,
-section[data-testid="stSidebar"] .sidebar-signout button {
+section[data-testid="stSidebar"] div[data-testid="stButton"] button[data-testid="baseButton-secondary"],
+section[data-testid="stSidebar"] div[data-testid="stButton"] button[kind="secondary"] {
   width: 100%;
   border-radius: 999px;
   border: 1px solid rgba(248, 113, 113, 0.6);
@@ -267,20 +269,20 @@ section[data-testid="stSidebar"] .sidebar-signout button {
     transform 0.2s ease;
 }
 
-section[data-testid="stSidebar"] .sidebar-signout div[data-testid="baseButton-secondary"] > button:hover,
-section[data-testid="stSidebar"] .sidebar-signout button:hover {
+section[data-testid="stSidebar"] div[data-testid="stButton"] button[data-testid="baseButton-secondary"]:hover,
+section[data-testid="stSidebar"] div[data-testid="stButton"] button[kind="secondary"]:hover {
   background: rgba(248, 113, 113, 0.2);
   color: #ffe4e6;
   border-color: rgba(248, 113, 113, 0.8);
   transform: translateY(-1px);
 }
 
-section[data-testid="stSidebar"] .sidebar-signout div[data-testid="baseButton-secondary"] > button:active,
-section[data-testid="stSidebar"] .sidebar-signout button:active {
+section[data-testid="stSidebar"] div[data-testid="stButton"] button[data-testid="baseButton-secondary"]:active,
+section[data-testid="stSidebar"] div[data-testid="stButton"] button[kind="secondary"]:active {
   transform: translateY(0);
 }
 
-.sb-footer {
+.sb-footer-line {
   margin-top: 1.25rem;
   padding-top: 1.1rem;
   border-top: 1px solid rgba(255, 255, 255, 0.06);
@@ -319,17 +321,17 @@ section[data-testid="stSidebar"] .sidebar-signout button:active {
   section[data-testid="stSidebar"] [role="radiogroup"] > label,
   section[data-testid="stSidebar"] [role="radiogroup"] > label::before,
   section[data-testid="stSidebar"] [role="radiogroup"] > label::after,
-  section[data-testid="stSidebar"] .sidebar-signout button,
-  section[data-testid="stSidebar"] .sidebar-signout div[data-testid="baseButton-secondary"] > button {
+  section[data-testid="stSidebar"] div[data-testid="stButton"] button[data-testid="baseButton-secondary"],
+  section[data-testid="stSidebar"] div[data-testid="stButton"] button[kind="secondary"] {
     transition: none;
     transform: none;
   }
 }
 
 @supports not (backdrop-filter: blur(4px)) {
-  .sidebar-header,
-  .sidebar-nav,
-  .sidebar-profile-card {
+  .sb-header-card,
+  section[data-testid="stSidebar"] div[data-testid="stRadio"],
+  .sb-profile-card {
     background: rgba(18, 24, 40, 0.88);
   }
 }

--- a/app/ui/sidebar.py
+++ b/app/ui/sidebar.py
@@ -1,10 +1,14 @@
 # path: app/ui/sidebar.py
 
 from __future__ import annotations
+
+import base64
 import json
+from functools import lru_cache
 from html import escape
 from pathlib import Path
 from typing import Callable, Dict, Iterable, List
+
 import streamlit as st
 
 
@@ -54,20 +58,19 @@ def build_sidebar(
     go: Callable[[str], None],
     logout: Callable[[], None],
 ) -> None:
-    """Render the application sidebar (English-only, tidy header, no stray boxes)."""
+    """Render the application sidebar with a minimal wrapper structure."""
 
     root = Path(__file__).resolve().parents[2]
     nav_options: List[str] = list(nav_keys)
     nav_display = {key: nav_labels.get(key, key) for key in nav_options}
 
-    # Keep font stack + logo sizing. Removed nonstandard :contains() alert-hiding CSS.
     st.markdown(
         """
         <style>
           section[data-testid="stSidebar"]{
             font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
           }
-          .sidebar-logo img{
+          .sb-logo img{
             display:block; margin:0 auto; width:100%; max-width:180px; height:auto; border-radius:18px;
             box-shadow:0 22px 38px rgba(12,20,44,.45);
           }
@@ -76,7 +79,6 @@ def build_sidebar(
         unsafe_allow_html=True,
     )
 
-    # Keep: move any Streamlit alerts to the bottom so header/nav eivät rikkoudu.
     st.markdown(
         """
         <script>
@@ -84,8 +86,8 @@ def build_sidebar(
           const doc = window.parent?.document ?? document;
           const sb = doc.querySelector('section[data-testid="stSidebar"]');
           if (!sb) return;
-          const shell = sb.querySelector('.sidebar-shell') || sb;
-          const footer = sb.querySelector('.sb-footer')?.parentElement || shell.lastElementChild || shell;
+          const shell = sb.querySelector('.block-container') || sb;
+          const footer = sb.querySelector('.sb-footer-line')?.parentElement || shell.lastElementChild || shell;
           const alerts = sb.querySelectorAll('.stAlert');
           if (!alerts.length) return;
           alerts.forEach(alert => {
@@ -99,34 +101,34 @@ def build_sidebar(
         unsafe_allow_html=True,
     )
 
+    logo_data_uri = _get_logo_data_uri(str(root / "assets" / "logo.png"))
+    tagline_html = f"<div class='sb-tagline'>{escape(app_tagline)}</div>" if app_tagline else ""
+    logo_html = (
+        f"<div class='sb-logo'><img src=\"{logo_data_uri}\" alt=\"{escape(app_title)} logo\" loading=\"lazy\"/></div>"
+        if logo_data_uri
+        else ""
+    )
+
+    header_html = (
+        """
+        <div class='sb-header-card'>
+          __LOGO__
+          <div class='sb-title-block'>
+            <div class='sb-title'>__TITLE__</div>
+            __TAGLINE__
+          </div>
+        </div>
+        """
+        .replace("__LOGO__", logo_html)
+        .replace("__TITLE__", escape(app_title))
+        .replace("__TAGLINE__", tagline_html)
+    )
+
     with st.sidebar:
-        st.markdown("<div class='sidebar-shell'>", unsafe_allow_html=True)
+        st.markdown(header_html, unsafe_allow_html=True)
 
-        # ---------- HEADER (one wrapper; no extra/empty divs) ----------
-        st.markdown("<div class='sidebar-header'>", unsafe_allow_html=True)
-
-        st.markdown("<div class='sidebar-logo'>", unsafe_allow_html=True)
-        st.image(str(root / "assets" / "logo.png"), use_container_width=True)
-        st.markdown("</div>", unsafe_allow_html=True)  # /sidebar-logo
-
-        tagline_html = f"<div class='scout-sub'>{escape(app_tagline)}</div>" if app_tagline else ""
-        st.markdown(
-            f"""
-            <div class='sidebar-title'>
-              <div class='scout-brand'>{escape(app_title)}</div>
-              {tagline_html}
-            </div>
-            """,
-            unsafe_allow_html=True,
-        )
-
-        st.markdown("</div>", unsafe_allow_html=True)  # /sidebar-header
-
-        # ---------- NAV (one wrapper; no extra/empty divs) ----------
         if nav_options:
-            st.markdown("<div class='sidebar-nav'>", unsafe_allow_html=True)
-            st.markdown("<div class='nav-title'>Navigation</div>", unsafe_allow_html=True)
-
+            st.markdown("<div class='sb-nav-title'>Navigation</div>", unsafe_allow_html=True)
             st.radio(
                 "Navigate",
                 options=nav_options,
@@ -137,9 +139,6 @@ def build_sidebar(
                 on_change=lambda: go(st.session_state["_nav_radio"]),
             )
 
-            st.markdown("</div>", unsafe_allow_html=True)  # /sidebar-nav
-
-        # ---------- ICONS for radio labels ----------
         if nav_options:
             icon_map = {key: nav_icons.get(key, "") for key in nav_options}
             st.markdown(
@@ -148,21 +147,48 @@ def build_sidebar(
                 (function attachIcons() {
                   const ICON_MAP = __ICON_MAP__;
                   const rootDoc = (window.parent && window.parent.document) ? window.parent.document : document;
-                  const labels = rootDoc.querySelectorAll('section[data-testid="stSidebar"] [role="radiogroup"] > label');
-                  labels.forEach((label) => {
-                    const input = label.querySelector('input');
-                    if (!input) return;
-                    const icon = ICON_MAP[input.value] || '';
-                    if (icon) label.setAttribute('data-icon', icon);
-                    else label.removeAttribute('data-icon');
-                  });
+
+                  function applyIcons() {
+                    const container = rootDoc.querySelector('section[data-testid="stSidebar"]');
+                    if (!container) return;
+                    const labels = container.querySelectorAll('[role="radiogroup"] > label');
+                    labels.forEach((label) => {
+                      const input = label.querySelector('input');
+                      if (!input) return;
+                      const iconChar = ICON_MAP[input.value] || '';
+                      let iconSpan = label.querySelector('.sb-nav-icon');
+                      if (!iconChar) {
+                        if (iconSpan) iconSpan.remove();
+                        return;
+                      }
+                      if (!iconSpan) {
+                        iconSpan = rootDoc.createElement('span');
+                        iconSpan.className = 'sb-nav-icon';
+                        iconSpan.setAttribute('aria-hidden', 'true');
+                        label.appendChild(iconSpan);
+                      }
+                      iconSpan.textContent = iconChar;
+                    });
+                  }
+
+                  applyIcons();
+
+                  const observer = new MutationObserver(() => applyIcons());
+                  function observeSidebar() {
+                    const container = rootDoc.querySelector('section[data-testid="stSidebar"]');
+                    if (!container) {
+                      setTimeout(observeSidebar, 120);
+                      return;
+                    }
+                    observer.observe(container, { childList: true, subtree: true });
+                  }
+                  observeSidebar();
                 })();
                 </script>
                 """.replace("__ICON_MAP__", json.dumps(icon_map)),
                 unsafe_allow_html=True,
             )
 
-        # ---------- PROFILE ----------
         auth = st.session_state.get("auth", {})
         user = auth.get("user")
         if auth.get("authenticated") and user:
@@ -180,7 +206,7 @@ def build_sidebar(
                 or ""
             )
             initials = "".join(p[0].upper() for p in display_name.split() if p)[:2] or "SL"
-            avatar_classes = "profile-avatar"
+            avatar_classes = "sb-profile-avatar"
             avatar_inner = ""
             if avatar_url:
                 avatar_classes += " has-image"
@@ -190,41 +216,60 @@ def build_sidebar(
                     )
                 )
 
-            st.markdown(
-                """
-                <div class='sidebar-profile-card'>
+            profile_html = """
+                <div class='sb-profile-card'>
                   <div class='{classes}' data-initials='{initials}'>{inner}</div>
-                  <div class='profile-meta'>
-                    <div class='profile-name'>{name}</div>
+                  <div class='sb-profile-meta'>
+                    <div class='sb-profile-name'>{name}</div>
                     {email_line}
                   </div>
                 </div>
-                """.format(
-                    classes=avatar_classes,
-                    initials=escape(initials),
-                    inner=avatar_inner,
-                    name=escape(display_name),
-                    email_line=(f"<div class='profile-email'>{escape(email)}</div>" if email else ""),
-                ),
-                unsafe_allow_html=True,
+            """.format(
+                classes=avatar_classes,
+                initials=escape(initials),
+                inner=avatar_inner,
+                name=escape(display_name),
+                email_line=(f"<div class='sb-profile-email'>{escape(email)}</div>" if email else ""),
             )
 
-            st.markdown("<div class='sidebar-signout'>", unsafe_allow_html=True)
+            st.markdown(profile_html, unsafe_allow_html=True)
             st.button("Sign out", on_click=logout, type="secondary", key="sidebar-signout")
-            st.markdown("</div>", unsafe_allow_html=True)  # /sidebar-signout
 
-        # ---------- FOOTER ----------
-        st.markdown(
+        footer_html = (
             """
-            <div class='sb-footer'>
+            <div class='sb-footer-line'>
               <span class='sb-footer-title'>{title}</span>
               <span class='sb-version'>v{version}</span>
             </div>
-            """.format(title=escape(app_title), version=escape(app_version)),
-            unsafe_allow_html=True,
+            """.format(title=escape(app_title), version=escape(app_version))
         )
+        st.markdown(footer_html, unsafe_allow_html=True)
 
-        st.markdown("</div>", unsafe_allow_html=True)  # /sidebar-shell
+
+@lru_cache(maxsize=1)
+def _get_logo_data_uri(path_str: str) -> str:
+    """Return a base64 data URI for the sidebar logo (empty if missing)."""
+
+    path = Path(path_str)
+    if not path.exists():
+        return ""
+
+    try:
+        data = path.read_bytes()
+    except OSError:
+        return ""
+
+    mime = "image/png"
+    suffix = path.suffix.lower()
+    if suffix == ".jpg" or suffix == ".jpeg":
+        mime = "image/jpeg"
+    elif suffix == ".svg":
+        mime = "image/svg+xml"
+    elif suffix == ".gif":
+        mime = "image/gif"
+
+    encoded = base64.b64encode(data).decode("ascii")
+    return f"data:{mime};base64,{encoded}"
 
 
 __all__ = ["bootstrap_sidebar_auto_collapse", "build_sidebar"]


### PR DESCRIPTION
## Summary
- flatten the sidebar markup to avoid extra wrapper divs and load the logo via a cached data URI
- update the icon injection script and alert relocation helper to work with the leaner structure
- refresh sidebar styling to target the native Streamlit blocks while preserving the visual design
- render Font Awesome icons on the navigation radio options for Reports, Notes, and other entries so they display reliably

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d0d0378fe883209c5bdfb06e60d650