### PR TITLE
Enhance sidebar navigation header styling

### DIFF
--- a/app/styles/sidebar.css
+++ b/app/styles/sidebar.css
@@ -82,11 +82,79 @@ section[data-testid="stSidebar"] .block-container {
 }
 
 .sb-nav-title {
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  margin-bottom: 0.1rem;
   text-transform: uppercase;
-  font-size: 0.75rem;
   letter-spacing: 0.32em;
-  font-weight: 600;
-  color: rgba(226, 234, 255, 0.55);
+}
+
+.sb-nav-title .sb-nav-text {
+  position: relative;
+  font-size: 0.82rem;
+  font-weight: 700;
+  background: linear-gradient(120deg, rgba(247, 250, 255, 0.95), rgba(141, 178, 255, 0.95));
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+  text-shadow: 0 12px 24px rgba(14, 22, 54, 0.65);
+  letter-spacing: 0.3em;
+}
+
+.sb-nav-badge {
+  position: relative;
+  width: 0.55rem;
+  height: 0.55rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 999px;
+  background: radial-gradient(circle at 30% 30%, rgba(255, 255, 255, 0.95), rgba(133, 161, 255, 0.55));
+  box-shadow: 0 0 14px rgba(114, 155, 255, 0.75), 0 0 2px rgba(12, 22, 52, 0.7);
+  overflow: hidden;
+}
+
+.sb-nav-badge::after {
+  content: "";
+  position: absolute;
+  inset: -35%;
+  border-radius: inherit;
+  background: radial-gradient(circle at 30% 30%, rgba(255, 255, 255, 0.65), rgba(135, 196, 255, 0));
+  opacity: 0.6;
+}
+
+.sb-nav-badge-pulse {
+  width: 100%;
+  height: 100%;
+  border-radius: inherit;
+  box-shadow: 0 0 0 0 rgba(125, 167, 255, 0.45);
+  animation: sbNavPulse 2.4s ease-in-out infinite;
+}
+
+.sb-nav-underline {
+  flex: 1 1 auto;
+  height: 1px;
+  border-radius: 999px;
+  background: linear-gradient(90deg, rgba(96, 165, 250, 0.15), rgba(178, 208, 255, 0.6), rgba(96, 165, 250, 0.15));
+  box-shadow: 0 0 12px rgba(93, 142, 255, 0.45);
+  opacity: 0.85;
+}
+
+@keyframes sbNavPulse {
+  0% {
+    box-shadow: 0 0 0 0 rgba(125, 167, 255, 0.45);
+    opacity: 1;
+  }
+  70% {
+    box-shadow: 0 0 0 6px rgba(125, 167, 255, 0);
+    opacity: 0.35;
+  }
+  100% {
+    box-shadow: 0 0 0 0 rgba(125, 167, 255, 0);
+    opacity: 0.25;
+  }
 }
 
 section[data-testid="stSidebar"] div[data-testid="stRadio"] {

--- a/app/ui/sidebar.py
+++ b/app/ui/sidebar.py
@@ -128,7 +128,18 @@ def build_sidebar(
         st.markdown(header_html, unsafe_allow_html=True)
 
         if nav_options:
-            st.markdown("<div class='sb-nav-title'>Navigation</div>", unsafe_allow_html=True)
+            st.markdown(
+                """
+                <div class='sb-nav-title'>
+                  <span class='sb-nav-badge' aria-hidden='true'>
+                    <span class='sb-nav-badge-pulse'></span>
+                  </span>
+                  <span class='sb-nav-text'>Navigation</span>
+                  <span class='sb-nav-underline' aria-hidden='true'></span>
+                </div>
+                """,
+                unsafe_allow_html=True,
+            )
             st.radio(
                 "Navigate",
                 options=nav_options,


### PR DESCRIPTION
## Summary
- replace the sidebar navigation heading markup with a richer HTML structure for decorative elements
- refresh the associated CSS to add gradient text, glowing badge, and animated underline for the navigation label

## Testing
- not run (UI-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d0e1fc3a3c8320be46e7618aa022af