### PR TITLE
codex: refresh sidebar navigation styling

### DIFF
--- a/app/styles/sidebar.css
+++ b/app/styles/sidebar.css
@@ -158,94 +158,229 @@ section[data-testid="stSidebar"] .block-container {
 }
 
 section[data-testid="stSidebar"] div[data-testid="stRadio"] {
+  position: relative;
   flex: 1 1 auto;
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
-  padding: 1.1rem 1rem;
-  border-radius: 22px;
+  gap: 0.85rem;
+  padding: 1.2rem 1.05rem 1.25rem;
+  border-radius: 26px;
   border: 1px solid rgba(255, 255, 255, 0.05);
-  background: rgba(15, 21, 36, 0.72);
-  box-shadow: 0 24px 45px rgba(7, 11, 24, 0.32);
-  backdrop-filter: blur(18px);
+  background: linear-gradient(160deg, rgba(19, 29, 54, 0.92), rgba(11, 17, 34, 0.82)),
+    rgba(15, 21, 36, 0.72);
+  box-shadow: 0 28px 48px rgba(6, 10, 22, 0.38);
+  backdrop-filter: blur(20px);
+  overflow: hidden;
+  isolation: isolate;
+}
+
+section[data-testid="stSidebar"] div[data-testid="stRadio"]::before,
+section[data-testid="stSidebar"] div[data-testid="stRadio"]::after {
+  content: "";
+  position: absolute;
+  border-radius: 50%;
+  filter: blur(0px);
+  pointer-events: none;
+  opacity: 0.32;
+}
+
+section[data-testid="stSidebar"] div[data-testid="stRadio"]::before {
+  top: -52%;
+  left: -44%;
+  width: 360px;
+  height: 360px;
+  background: radial-gradient(circle at 30% 30%, rgba(94, 141, 255, 0.85), rgba(94, 141, 255, 0));
+}
+
+section[data-testid="stSidebar"] div[data-testid="stRadio"]::after {
+  bottom: -48%;
+  right: -38%;
+  width: 320px;
+  height: 320px;
+  background: radial-gradient(circle at 70% 70%, rgba(104, 224, 255, 0.75), rgba(104, 224, 255, 0));
+  opacity: 0.22;
 }
 
 section[data-testid="stSidebar"] [role="radiogroup"] {
   display: flex;
   flex-direction: column;
-  gap: 0.6rem;
+  gap: 0.85rem;
 }
 
 section[data-testid="stSidebar"] [role="radiogroup"] > label {
   position: relative;
   display: flex;
   align-items: center;
-  gap: 0.5rem;
-  padding: 0.8rem 1.1rem 0.8rem 3.1rem;
-  border-radius: 16px;
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  background: rgba(255, 255, 255, 0.02);
-  color: rgba(236, 242, 255, 0.82);
-  font-size: 0.95rem;
+  gap: 1rem;
+  padding: 1rem 1.25rem 1rem 3.9rem;
+  border-radius: 20px;
+  border: 1px solid rgba(255, 255, 255, 0.07);
+  background: linear-gradient(145deg, rgba(26, 38, 72, 0.9), rgba(17, 25, 49, 0.78));
+  color: rgba(236, 242, 255, 0.86);
+  font-size: 0.98rem;
   font-weight: 500;
-  line-height: 1.3;
+  line-height: 1.28;
   letter-spacing: 0.01em;
-  transition: background 0.25s ease, color 0.25s ease, border-color 0.25s ease,
-    box-shadow 0.25s ease, transform 0.25s ease;
+  box-shadow: 0 24px 44px rgba(8, 13, 31, 0.38);
+  transition: transform 0.3s ease, background 0.3s ease, color 0.3s ease,
+    border-color 0.3s ease, box-shadow 0.3s ease, filter 0.3s ease;
   cursor: pointer;
   overflow: hidden;
+  isolation: isolate;
+}
+
+section[data-testid="stSidebar"] [role="radiogroup"] > label::before {
+  content: "";
+  position: absolute;
+  left: 1.05rem;
+  top: 50%;
+  width: 2.7rem;
+  height: 2.7rem;
+  border-radius: 1rem;
+  background: linear-gradient(140deg, rgba(113, 143, 255, 0.4), rgba(74, 128, 255, 0.18));
+  box-shadow: 0 16px 34px rgba(28, 54, 125, 0.32);
+  transform: translateY(-50%) scale(1);
+  opacity: 0.92;
+  transition: transform 0.3s ease, opacity 0.3s ease, background 0.3s ease,
+    box-shadow 0.3s ease;
+  z-index: 0;
+}
+
+section[data-testid="stSidebar"] [role="radiogroup"] > label::after {
+  content: attr(data-option);
+  position: absolute;
+  right: 1.4rem;
+  bottom: -0.7rem;
+  font-size: 2.35rem;
+  font-weight: 700;
+  letter-spacing: 0.32em;
+  color: rgba(255, 255, 255, 0.05);
+  text-transform: uppercase;
+  pointer-events: none;
+  opacity: 0;
+  transform: translateY(14px);
+  transition: opacity 0.35s ease, transform 0.35s ease, letter-spacing 0.35s ease;
+  z-index: 0;
 }
 
 section[data-testid="stSidebar"] [role="radiogroup"] > label .sb-nav-icon {
   position: absolute;
   left: 1.15rem;
   top: 50%;
-  transform: translateY(-50%);
+  width: 2.7rem;
+  height: 2.7rem;
+  border-radius: 1rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   font-family: "Font Awesome 6 Free";
   font-weight: 900;
-  font-size: 1.05rem;
-  color: rgba(218, 225, 255, 0.7);
-  transition: color 0.25s ease, transform 0.25s ease;
+  font-size: 1.12rem;
+  color: rgba(222, 228, 255, 0.84);
+  text-shadow: 0 10px 22px rgba(17, 25, 56, 0.45);
+  background: rgba(115, 149, 255, 0.16);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.05);
+  backdrop-filter: blur(6px);
+  transform: translateY(-50%) scale(1);
+  transition: transform 0.3s ease, color 0.3s ease, background 0.3s ease,
+    box-shadow 0.3s ease;
   pointer-events: none;
+  z-index: 1;
+}
+
+section[data-testid="stSidebar"] [role="radiogroup"] > label .sb-nav-label {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  font-weight: 600;
+  font-size: 1rem;
+  color: inherit;
+  text-shadow: 0 12px 30px rgba(10, 17, 42, 0.55);
+}
+
+section[data-testid="stSidebar"] [role="radiogroup"] > label .sb-nav-label::after {
+  content: "Open section";
+  font-size: 0.72rem;
+  letter-spacing: 0.26em;
+  text-transform: uppercase;
+  color: rgba(214, 225, 255, 0.42);
+  transition: color 0.25s ease, letter-spacing 0.25s ease, transform 0.25s ease,
+    opacity 0.25s ease;
 }
 
 section[data-testid="stSidebar"] [role="radiogroup"] > label:hover {
-  transform: translateX(4px);
-  background: rgba(88, 128, 255, 0.12);
-  border-color: rgba(120, 160, 255, 0.35);
-  color: rgba(250, 253, 255, 0.95);
-  box-shadow: 0 16px 30px rgba(16, 28, 66, 0.35);
+  transform: translateX(6px) scale(1.01);
+  background: linear-gradient(150deg, rgba(58, 83, 168, 0.82), rgba(33, 51, 109, 0.75));
+  border-color: rgba(152, 187, 255, 0.55);
+  color: rgba(248, 250, 255, 0.96);
+  box-shadow: 0 26px 48px rgba(10, 19, 45, 0.45);
+}
+
+section[data-testid="stSidebar"] [role="radiogroup"] > label:hover::before {
+  transform: translateY(-50%) scale(1.08);
+  background: linear-gradient(150deg, rgba(128, 160, 255, 0.68), rgba(83, 133, 255, 0.32));
+  box-shadow: 0 20px 38px rgba(34, 66, 150, 0.4);
+}
+
+section[data-testid="stSidebar"] [role="radiogroup"] > label:hover::after {
+  opacity: 0.18;
+  transform: translateY(4px);
+  letter-spacing: 0.28em;
 }
 
 section[data-testid="stSidebar"] [role="radiogroup"] > label:hover .sb-nav-icon {
-  color: rgba(250, 253, 255, 0.85);
-  transform: translateY(-50%) scale(1.08);
+  background: rgba(134, 167, 255, 0.24);
+  color: rgba(255, 255, 255, 0.92);
+  transform: translateY(-50%) scale(1.06);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.12), 0 14px 28px rgba(26, 48, 122, 0.42);
+}
+
+section[data-testid="stSidebar"] [role="radiogroup"] > label:hover .sb-nav-label::after {
+  color: rgba(234, 242, 255, 0.75);
+  letter-spacing: 0.32em;
+  transform: translateY(-1px);
 }
 
 section[data-testid="stSidebar"] [role="radiogroup"] > label:has(input:checked) {
-  background: linear-gradient(135deg, rgba(99, 102, 241, 0.9), rgba(59, 130, 246, 0.85));
-  border-color: rgba(166, 191, 255, 0.85);
+  transform: translateX(4px) scale(1.01);
+  background: linear-gradient(145deg, rgba(72, 90, 255, 0.9), rgba(46, 135, 255, 0.92));
+  border-color: rgba(176, 206, 255, 0.92);
   color: #ffffff;
-  box-shadow: 0 18px 40px rgba(18, 35, 76, 0.55), inset 0 0 0 1px rgba(255, 255, 255, 0.22);
+  box-shadow: 0 30px 52px rgba(14, 31, 82, 0.55), inset 0 0 0 1px rgba(255, 255, 255, 0.18);
+  filter: drop-shadow(0 18px 32px rgba(50, 86, 175, 0.3));
 }
 
-section[data-testid="stSidebar"] [role="radiogroup"] > label:has(input:checked) .sb-nav-icon {
-  color: #ffffff;
+section[data-testid="stSidebar"] [role="radiogroup"] > label:has(input:checked)::before {
+  background: linear-gradient(145deg, rgba(173, 191, 255, 0.95), rgba(118, 164, 255, 0.6));
+  box-shadow: 0 22px 42px rgba(40, 78, 168, 0.5);
   transform: translateY(-50%) scale(1.12);
+  opacity: 1;
 }
 
 section[data-testid="stSidebar"] [role="radiogroup"] > label:has(input:checked)::after {
-  content: "";
-  position: absolute;
-  inset: 0;
-  border-radius: 16px;
-  box-shadow: inset 0 0 0 1.5px rgba(255, 255, 255, 0.28), 0 0 25px rgba(101, 168, 255, 0.45);
-  pointer-events: none;
+  opacity: 0.28;
+  transform: translateY(0px);
+  letter-spacing: 0.26em;
+}
+
+section[data-testid="stSidebar"] [role="radiogroup"] > label:has(input:checked) .sb-nav-icon {
+  background: linear-gradient(145deg, #6366f1, #3b82f6);
+  color: #ffffff;
+  transform: translateY(-50%) scale(1.08);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.25), 0 18px 36px rgba(45, 92, 212, 0.48);
+}
+
+section[data-testid="stSidebar"] [role="radiogroup"] > label:has(input:checked) .sb-nav-label::after {
+  content: "Now viewing";
+  color: rgba(255, 255, 255, 0.78);
+  letter-spacing: 0.35em;
 }
 
 section[data-testid="stSidebar"] [role="radiogroup"] > label:focus-within {
   outline: none;
-  box-shadow: 0 0 0 2px rgba(99, 102, 241, 0.55), 0 0 0 5px rgba(96, 165, 250, 0.3);
+  box-shadow: 0 0 0 2px rgba(99, 102, 241, 0.45), 0 0 0 5px rgba(96, 165, 250, 0.28);
 }
 
 section[data-testid="stSidebar"] a {
@@ -385,10 +520,50 @@ section[data-testid="stSidebar"] div[data-testid="stButton"] button[kind="second
   }
 }
 
+@media (max-width: 520px) {
+  section[data-testid="stSidebar"] div[data-testid="stRadio"] {
+    padding: 1rem 0.85rem 1.1rem;
+    border-radius: 22px;
+    gap: 0.75rem;
+  }
+
+  section[data-testid="stSidebar"] [role="radiogroup"] > label {
+    padding: 0.85rem 0.95rem 0.9rem 3.45rem;
+    border-radius: 18px;
+  }
+
+  section[data-testid="stSidebar"] [role="radiogroup"] > label::before,
+  section[data-testid="stSidebar"] [role="radiogroup"] > label .sb-nav-icon {
+    width: 2.4rem;
+    height: 2.4rem;
+    border-radius: 0.9rem;
+  }
+
+  section[data-testid="stSidebar"] [role="radiogroup"] > label::after {
+    font-size: 1.9rem;
+    right: 1rem;
+    bottom: -0.6rem;
+    letter-spacing: 0.28em;
+  }
+
+  section[data-testid="stSidebar"] [role="radiogroup"] > label .sb-nav-label {
+    font-size: 0.95rem;
+    gap: 0.25rem;
+  }
+
+  section[data-testid="stSidebar"] [role="radiogroup"] > label .sb-nav-label::after {
+    font-size: 0.68rem;
+    letter-spacing: 0.22em;
+  }
+}
+
 @media (prefers-reduced-motion: reduce) {
+  section[data-testid="stSidebar"] div[data-testid="stRadio"],
   section[data-testid="stSidebar"] [role="radiogroup"] > label,
   section[data-testid="stSidebar"] [role="radiogroup"] > label::before,
   section[data-testid="stSidebar"] [role="radiogroup"] > label::after,
+  section[data-testid="stSidebar"] [role="radiogroup"] > label .sb-nav-icon,
+  section[data-testid="stSidebar"] [role="radiogroup"] > label .sb-nav-label::after,
   section[data-testid="stSidebar"] div[data-testid="stButton"] button[data-testid="baseButton-secondary"],
   section[data-testid="stSidebar"] div[data-testid="stButton"] button[kind="secondary"] {
     transition: none;

--- a/app/ui/sidebar.py
+++ b/app/ui/sidebar.py
@@ -170,15 +170,24 @@ def build_sidebar(
                       let iconSpan = label.querySelector('.sb-nav-icon');
                       if (!iconChar) {
                         if (iconSpan) iconSpan.remove();
-                        return;
+                      } else {
+                        if (!iconSpan) {
+                          iconSpan = rootDoc.createElement('span');
+                          iconSpan.className = 'sb-nav-icon';
+                          iconSpan.setAttribute('aria-hidden', 'true');
+                          label.appendChild(iconSpan);
+                        }
+                        iconSpan.textContent = iconChar;
                       }
-                      if (!iconSpan) {
-                        iconSpan = rootDoc.createElement('span');
-                        iconSpan.className = 'sb-nav-icon';
-                        iconSpan.setAttribute('aria-hidden', 'true');
-                        label.appendChild(iconSpan);
+
+                      label.classList.add('sb-nav-item');
+                      label.dataset.option = input.value;
+                      label.dataset.active = input.checked ? 'true' : 'false';
+
+                      const textBlock = label.querySelector(':scope > div:last-child');
+                      if (textBlock && !textBlock.classList.contains('sb-nav-label')) {
+                        textBlock.classList.add('sb-nav-label');
                       }
-                      iconSpan.textContent = iconChar;
                     });
                   }
 


### PR DESCRIPTION
## Summary
- enhance sidebar navigation script to decorate each radio option with styling hooks
- restyle navigation card, icons, and responsive breakpoints for a richer glassmorphism look
- add reduced-motion and small-screen tweaks to keep the updated navigation accessible

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d0e46aa7288320a10f7a3998757be4