### PR TITLE
Enforce guarded dark sidebar

### DIFF
--- a/app/styles/sidebar.css
+++ b/app/styles/sidebar.css
@@ -29,20 +29,6 @@
   --sb-width-sm: 260px;
 }
 
-/* Light mode tuki */
-@media (prefers-color-scheme: light) {
-  :root {
-    --bg: #f8f9fb;
-    --bg-elev: #ffffff;
-    --bg-soft: #f1f3f7;
-    --ink: #111;
-    --ink-dim: #333;
-    --muted: #555;
-    --border: #d0d7e2;
-    --shadow: 0 6px 18px rgba(0,0,0,.12);
-  }
-}
-
 /* ===== Sidebar ===== */
 :where(section[data-testid="stSidebar"]) {
   background: radial-gradient(1200px 600px at 15% -10%, rgba(255,255,255,.03), transparent 60%), var(--bg);
@@ -107,22 +93,19 @@
 }
 
 :where(section[data-testid="stSidebar"] [role="radiogroup"] > label){
-  position:relative; display:flex; align-items:center; gap:.9rem;
+  position:relative; display:flex; align-items:center; gap:1rem;
   width:100%; box-sizing:border-box;
-  padding:1rem 1.25rem 1rem 3.9rem;
+  padding:.95rem 1.25rem .95rem 3.75rem;
+  min-height:3.1rem;
   border-radius: var(--radius-md);
   border:1px solid var(--border);
   background: var(--bg-elev);
-  color:var(--ink);
+  color:var(--ink-dim);
   font-size:.98rem;
   font-weight:600;
+  line-height:1.3;
   transition: transform .18s, background .18s, border-color .18s, color .18s, box-shadow .18s;
   cursor:pointer;
-}
-
-:where(section[data-testid="stSidebar"] [role="radiogroup"] > label)::before,
-:where(section[data-testid="stSidebar"] [role="radiogroup"] > label .sb-nav-icon){
-  width:2.6rem; height:2.6rem; border-radius:.9rem;
 }
 
 :where(section[data-testid="stSidebar"] [role="radiogroup"] > label:hover){
@@ -131,16 +114,58 @@
   border-color: color-mix(in oklab, var(--border), white 6%);
 }
 
-:where(section[data-testid="stSidebar"] [role="radiogroup"] > label:has(input:checked)){
+:where(section[data-testid="stSidebar"] [role="radiogroup"] > label[data-active="true"]),
+:where(section[data-testid="stSidebar"] [role="radiogroup"] > label[aria-current="page"]){
   background:linear-gradient(0deg, rgba(99,102,241,.06), rgba(99,102,241,.06)), var(--bg-soft);
   border-color:color-mix(in oklab, var(--accent-2), black 65%);
   box-shadow: var(--shadow), inset 0 0 0 1px rgba(255,255,255,.02);
   color:var(--ink);
 }
 
+:where(section[data-testid="stSidebar"] [role="radiogroup"] > label[data-active="true"] .sb-nav-icon),
+:where(section[data-testid="stSidebar"] [role="radiogroup"] > label[aria-current="page"] .sb-nav-icon){
+  background:color-mix(in oklab, var(--accent-2), transparent 42%);
+  color:var(--ink);
+  box-shadow:inset 0 0 0 1px rgba(255,255,255,.14);
+}
+
 :where(section[data-testid="stSidebar"] [role="radiogroup"] > label:focus-within){
   outline:none;
   box-shadow:0 0 0 2px var(--ring), 0 0 0 5px rgba(109,145,255,.18);
+}
+
+.sb-nav-icon{
+  position:absolute;
+  left:1.15rem;
+  top:50%;
+  transform:translateY(-50%);
+  display:inline-flex;
+  align-items:center;
+  justify-content:center;
+  width:2.6rem;
+  height:2.6rem;
+  border-radius:.9rem;
+  background:color-mix(in oklab, var(--accent-2), transparent 68%);
+  color:color-mix(in oklab, var(--ink), black 10%);
+  font-size:1.1rem;
+  font-weight:900;
+  font-family:"Font Awesome 6 Free","Font Awesome 6 Pro","Inter",system-ui,sans-serif;
+  pointer-events:none;
+  transition:background .18s, color .18s, box-shadow .18s;
+}
+
+.sb-nav-icon i{ display:inline-block; font-style:normal; }
+
+:where(section[data-testid="stSidebar"] [role="radiogroup"] > label:hover .sb-nav-icon){
+  background:color-mix(in oklab, var(--accent-2), transparent 55%);
+}
+
+.sb-nav-label{
+  display:flex;
+  flex:1;
+  align-items:center;
+  gap:.25rem;
+  color:inherit;
 }
 
 /* ===== Profile ===== */


### PR DESCRIPTION
## Summary
- wrap `st.sidebar` in a guard so misuse outside `build_sidebar` is logged and surfaced in the main app body
- refactor `build_sidebar` to be the sole sidebar renderer, force the dark theme, and enhance navigation/profile/footer semantics
- refresh `app/styles/sidebar.css` to rely on a single dark palette with updated nav icon, hover, and focus styles for accessibility

## Testing
- python -m compileall app/app.py app/ui/sidebar.py

------
https://chatgpt.com/codex/tasks/task_e_68d5555168d083208e2a0130d9a4f4d6