### PR TITLE
Remove shortlist deletion option from shortlist page

### DIFF
--- a/app/shortlists_page.py
+++ b/app/shortlists_page.py
@@ -110,17 +110,7 @@ def show_shortlists_page() -> None:
         format_func=lambda x: next(s["name"] for s in shortlists if s["id"] == x),
     )
     st.session_state["shortlists__sid"] = sid
-
-    if st.button("Delete shortlist", type="secondary"):
-        try:
-            sb.table("shortlist_items").delete().eq("shortlist_id", sid).execute()
-            sb.table("shortlists").delete().eq("id", sid).execute()
-            list_shortlists.clear()
-            list_shortlist_items.clear()
-            st.toast("Shortlist deleted ✅")
-            st.rerun()
-        except APIError as e:  # pragma: no cover - UI error handling
-            st.error(f"Failed to delete shortlist: {e}")
+    st.caption("Delete shortlists from the Manage Shortlists page.")
 
     # add players
     st.subheader("Add players")


### PR DESCRIPTION
## Summary
- remove the delete shortlist button from the shortlists page
- guide users to delete lists through the manage shortlists view instead

## Testing
- not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68d610e162cc8320a884d00c4dbae492