### PR TITLE
codex: rerun immediately when navigating from sidebar

### DIFF
--- a/app/ui/nav.py
+++ b/app/ui/nav.py
@@ -4,8 +4,14 @@ import streamlit as st
 
 
 def go(page: str) -> None:
-    """Switch to the given page by updating session state."""
+    """Switch to the given page by updating session state and forcing a rerun."""
     st.session_state["current_page"] = page
+    # why: without an explicit rerun Streamlit finishes the current render with the
+    # previous page value, causing the sidebar to look "stuck" when users click
+    # navigation items quickly.
+    rerun = getattr(st, "rerun", None) or getattr(st, "experimental_rerun", None)
+    if rerun:
+        rerun()
 
 
 __all__ = ["go"]


### PR DESCRIPTION
## Summary
- trigger an explicit rerun whenever the sidebar navigation target changes
- prevent the interim render that left the sidebar looking stuck during rapid page switches

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d611b42c2083209c6564e8b76ce9db