### PR TITLE
Clean up post-login loading overlay

### DIFF
--- a/app/login.py
+++ b/app/login.py
@@ -29,9 +29,15 @@ def _ensure_auth_state() -> Dict[str, object]:
 
 
 def _render_post_login_loading() -> None:
-    st.markdown(
+    placeholder = st.empty()
+    placeholder.markdown(
         """
         <style>
+        html, body, .stApp { overflow: hidden !important; }
+        .stApp > header,
+        .stApp > div[data-testid="stToolbar"],
+        .stApp > div[data-testid="stDecoration"],
+        .stApp > div[data-testid="stSidebar"] { display: none !important; }
         .sl-login-loading-overlay {
             position: fixed;
             inset: 0;


### PR DESCRIPTION
## Summary
- render the post-login loading screen inside a Streamlit placeholder so it replaces any prior content cleanly
- hide the Streamlit header, toolbar, decoration, and sidebar while the loading overlay is visible to prevent overlapping UI

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d622780d9083208fc9cd9dfafda266