### PR TITLE
codex: disable autofill outside login

### DIFF
--- a/app/add_player_form.py
+++ b/app/add_player_form.py
@@ -105,12 +105,16 @@ def show_add_player_form():
         st.subheader("Perustiedot")
         c1, c2, c3 = st.columns([2,1.2,1])
         with c1:
-            name = st.text_input("Nimi *", placeholder="Etunimi Sukunimi")
+            name = st.text_input(
+                "Nimi *", placeholder="Etunimi Sukunimi", autocomplete="off"
+            )
         with c2:
             dob = st.date_input("Syntymäpäivä *", value=date(2004, 1, 1), min_value=date(1970,1,1), max_value=date.today())
             st.caption(f"Ikä: {_age_from_dob(dob)} v")
         with c3:
-            nationality = st.text_input("Kansallisuus", placeholder="ARG / BRA / URU ...")
+            nationality = st.text_input(
+                "Kansallisuus", placeholder="ARG / BRA / URU ...", autocomplete="off"
+            )
 
         c4, c5, c6 = st.columns([1,1,1])
         with c4:
@@ -132,7 +136,11 @@ def show_add_player_form():
 
         with st.expander("Lisätiedot (valinnainen)"):
             notes = st.text_area("Muistiinpanot")
-            tags = st.text_input("Tunnisteet (pilkulla eroteltuna)", placeholder="U23, trial, high-potential")
+            tags = st.text_input(
+                "Tunnisteet (pilkulla eroteltuna)",
+                placeholder="U23, trial, high-potential",
+                autocomplete="off",
+            )
 
         st.subheader("Kuva (valinnainen)")
         photo = st.file_uploader("Lataa pelaajakuva (PNG/JPG)", type=["png","jpg","jpeg"])

--- a/app/age_minutes.py
+++ b/app/age_minutes.py
@@ -22,7 +22,9 @@ def show_age_minutes() -> None:
         )
 
         if selected_team == "Create new team...":
-            new_team = st.text_input("New team name", key="age_minutes_new_team")
+            new_team = st.text_input(
+                "New team name", key="age_minutes_new_team", autocomplete="off"
+            )
             if st.button("Create Team", type="primary", key="age_minutes_create_team"):
                 if new_team.strip():
                     selected_team = new_team.strip()
@@ -43,10 +45,14 @@ def show_age_minutes() -> None:
 
         st.markdown("### Add or Update Player")
         with st.form("player_form"):
-            name = st.text_input("Name", key="age_minutes_player_name")
+            name = st.text_input("Name", key="age_minutes_player_name", autocomplete="off")
             age = st.number_input("Age", min_value=15, max_value=45, key="age_minutes_age")
-            position = st.text_input("Position", key="age_minutes_position")
-            nationality = st.text_input("Nationality", key="age_minutes_nationality")
+            position = st.text_input(
+                "Position", key="age_minutes_position", autocomplete="off"
+            )
+            nationality = st.text_input(
+                "Nationality", key="age_minutes_nationality", autocomplete="off"
+            )
             contract_start = st.date_input("Contract Start", key="age_minutes_contract_start")
             contract_end = st.date_input("Contract End", key="age_minutes_contract_end")
             loan = st.checkbox("On Loan", key="age_minutes_loan")

--- a/app/calendar_ui.py
+++ b/app/calendar_ui.py
@@ -170,18 +170,42 @@ def _form(default: Optional[Dict[str, Any]] = None) -> Optional[Dict[str, Any]]:
             except Exception:
                 pass
         date_val = st.date_input("Date", value=dval)
-        time_val = st.text_input("Time (HH:MM)", value=(default.get("time", "") if is_edit else ""))
+        time_val = st.text_input(
+            "Time (HH:MM)",
+            value=(default.get("time", "") if is_edit else ""),
+            autocomplete="off",
+        )
         tz_opts = [LOCAL_TZ] + LATAM_TZS
         tz_default = default.get("tz") if (is_edit and default.get("tz") in tz_opts) else LOCAL_TZ
         tz_val = st.selectbox("Time zone (IANA)", tz_opts, index=tz_opts.index(tz_default))
     with col2:
-        competition = st.text_input("Competition", value=(default.get("competition", "") if is_edit else ""))
-        city = st.text_input("City", value=(default.get("city", "") if is_edit else ""))
-        location = st.text_input("Stadium / Location", value=(default.get("location", "") if is_edit else ""))
+        competition = st.text_input(
+            "Competition",
+            value=(default.get("competition", "") if is_edit else ""),
+            autocomplete="off",
+        )
+        city = st.text_input(
+            "City",
+            value=(default.get("city", "") if is_edit else ""),
+            autocomplete="off",
+        )
+        location = st.text_input(
+            "Stadium / Location",
+            value=(default.get("location", "") if is_edit else ""),
+            autocomplete="off",
+        )
 
-    home = st.text_input("Home team", value=(default.get("home", "") if is_edit else ""))
-    away = st.text_input("Away team", value=(default.get("away", "") if is_edit else ""))
-    targets_str = st.text_input("Scout targets (comma-separated)", value=(",".join(default.get("targets", [])) if is_edit else ""))
+    home = st.text_input(
+        "Home team", value=(default.get("home", "") if is_edit else ""), autocomplete="off"
+    )
+    away = st.text_input(
+        "Away team", value=(default.get("away", "") if is_edit else ""), autocomplete="off"
+    )
+    targets_str = st.text_input(
+        "Scout targets (comma-separated)",
+        value=(",".join(default.get("targets", [])) if is_edit else ""),
+        autocomplete="off",
+    )
     notes = st.text_area("Notes", value=(default.get("notes", "") if is_edit else ""))
 
     c1, c2 = st.columns(2)

--- a/app/inspect_player.py
+++ b/app/inspect_player.py
@@ -88,7 +88,9 @@ def show_inspect_player() -> None:
     # --- Filters for reports ---
     st.markdown("### Match Reports")
     fc1, fc2 = st.columns([2, 1])
-    comp_filter = fc1.text_input("Filter by competition (contains)", "")
+    comp_filter = fc1.text_input(
+        "Filter by competition (contains)", "", autocomplete="off"
+    )
     date_range = fc2.date_input(
         "Date range",
         value=(),

--- a/app/notes.py
+++ b/app/notes.py
@@ -97,7 +97,12 @@ def show_notes():
             placeholder="Observation, idea, follow-up…"
         )
     with c2:
-        tags_str = st.text_input("Tags (comma-separated)", key="notes__new_tags", placeholder="e.g. U23, LW, Brazil")
+        tags_str = st.text_input(
+            "Tags (comma-separated)",
+            key="notes__new_tags",
+            placeholder="e.g. U23, LW, Brazil",
+            autocomplete="off",
+        )
         st.caption("Keep tags short; use commas to separate.")
 
     cc1, cc2, cc3 = st.columns([1,1,2.2])
@@ -125,7 +130,13 @@ def show_notes():
     st.subheader("Browse")
     b1, b2, b3, b4 = st.columns([1.6, 1.2, 1.2, 1.0])
     with b1:
-        q = st.text_input("Search text", key="notes__q", placeholder="find in text…").strip().lower()
+        raw_q = st.text_input(
+            "Search text",
+            key="notes__q",
+            placeholder="find in text…",
+            autocomplete="off",
+        )
+        q = (raw_q or "").strip().lower()
     # collect tag universe
     all_tags = []
     for n in notes:
@@ -195,7 +206,12 @@ def show_notes():
         ids = [n["id"] for n in page_items]
         picks = st.multiselect("Select notes to delete", options=ids, format_func=lambda nid: next((f"{_fmt_ts(n['created_at'])}  •  {(n['text'][:40] + '…' if len(n['text'])>40 else n['text'])}" for n in page_items if n['id']==nid), nid), key="notes__bulk")
         st.warning("Type DELETE to confirm bulk deletion.", icon="⚠️")
-        confirm = st.text_input("Confirmation", key="notes__confirm", placeholder="DELETE")
+        confirm = st.text_input(
+            "Confirmation",
+            key="notes__confirm",
+            placeholder="DELETE",
+            autocomplete="off",
+        )
         if st.button(
             f"🗑️ Delete selected ({len(picks)})",
             disabled=(len(picks)==0 or confirm!="DELETE"),
@@ -237,7 +253,12 @@ def show_notes():
                 # Inline edit
                 with st.expander("✏️ Edit"):
                     new_text = st.text_area("Edit text", value=n.get("text",""), key=f"notes__edit_text_{n['id']}", height=120)
-                    new_tags = st.text_input("Edit tags (comma-separated)", value=", ".join(n.get("tags",[])), key=f"notes__edit_tags_{n['id']}")
+                    new_tags = st.text_input(
+                        "Edit tags (comma-separated)",
+                        value=", ".join(n.get("tags", [])),
+                        key=f"notes__edit_tags_{n['id']}",
+                        autocomplete="off",
+                    )
                     if st.button("💾 Save changes", key=f"notes__edit_save_{n['id']}", type="primary"):
                         n["text"] = (new_text or "").strip()
                         n["tags"] = _clean_tags(new_tags or "")

--- a/app/player_editor.py
+++ b/app/player_editor.py
@@ -491,7 +491,9 @@ def show_player_editor():
         return _render_shortlist_flow()
 
     # --- TEAM FLOW ---
-    new_name = st.text_input("Create Team", placeholder="e.g. ATLÉTICO NACIONAL")
+    new_name = st.text_input(
+        "Create Team", placeholder="e.g. ATLÉTICO NACIONAL", autocomplete="off"
+    )
     if st.button(
         "➕ Create Team",
         type="primary",
@@ -524,7 +526,12 @@ def _render_shortlist_flow():
         st.info(
             "Ei shortlisteja vielä. Luo listat Home/Team View -sivuilla tai luo uusi tässä."
         )
-        new_name = st.text_input("Uuden shortlistin nimi", value="default", key="pe_new_shortlist_name")
+        new_name = st.text_input(
+            "Uuden shortlistin nimi",
+            value="default",
+            key="pe_new_shortlist_name",
+            autocomplete="off",
+        )
         if st.button("Luo shortlist", type="primary"):
             if new_name.strip():
                 shortlists[new_name.strip()] = []
@@ -671,7 +678,9 @@ def _render_team_editor_flow(selected_team: str, preselected_name: Optional[str]
     st.subheader("🔍 Find Player (single-row editor)")
     c_s1, c_s2 = st.columns([3, 1])
     with c_s1:
-        search_term = st.text_input("Search by name", key=f"pe_search__{selected_team}")
+        search_term = st.text_input(
+            "Search by name", key=f"pe_search__{selected_team}", autocomplete="off"
+        )
     with c_s2:
         sort_by = st.selectbox(
             "Sort by",
@@ -717,13 +726,21 @@ def _render_team_editor_flow(selected_team: str, preselected_name: Optional[str]
 
         c1, c2, c3 = st.columns(3)
         with c1:
-            st.text_input("PlayerID", value=pid_str, disabled=True)
+            st.text_input("PlayerID", value=pid_str, disabled=True, autocomplete="off")
         with c2:
             name_val = st.text_input(
-                "Name", value=_as_str(row.get("Name", "")), key=f"{selected_team}_{pid_str}_name"
+                "Name",
+                value=_as_str(row.get("Name", "")),
+                key=f"{selected_team}_{pid_str}_name",
+                autocomplete="off",
             )
         with c3:
-            st.text_input("Team (master file)", value=str(selected_team), disabled=True)
+            st.text_input(
+                "Team (master file)",
+                value=str(selected_team),
+                disabled=True,
+                autocomplete="off",
+            )
 
         c4, c5, c6 = st.columns(3)
         with c4:
@@ -735,10 +752,14 @@ def _render_team_editor_flow(selected_team: str, preselected_name: Optional[str]
                 "Nationality (A, B)",
                 value=_normalize_nationality(_as_str(row.get("Nationality", ""))),
                 key=f"{selected_team}_{pid_str}_nat",
+                autocomplete="off",
             )
         with c6:
             pos_val = st.text_input(
-                "Position", value=_as_str(row.get("Position", "")), key=f"{selected_team}_{pid_str}_pos"
+                "Position",
+                value=_as_str(row.get("Position", "")),
+                key=f"{selected_team}_{pid_str}_pos",
+                autocomplete="off",
             )
 
         c7, c8, c9 = st.columns(3)
@@ -767,6 +788,7 @@ def _render_team_editor_flow(selected_team: str, preselected_name: Optional[str]
             value=_as_str(row.get("TransfermarktURL", "")),
             placeholder="https://www.transfermarkt.com/...",
             key=f"{selected_team}_{pid_str}_tmurl",
+            autocomplete="off",
         )
         if tm_url_val and not _valid_tm_url(tm_url_val):
             st.warning("URL ei näytä Transfermarkt-osoitteelta.")
@@ -868,7 +890,10 @@ def _render_team_editor_flow(selected_team: str, preselected_name: Optional[str]
         tags_key = f"tags_{pid_str}"
         current_tags = st.session_state.get(tags_key, "")
         tag_str = st.text_input(
-            "Tags (comma-separated)", value=current_tags, key=f"{selected_team}_{pid_str}_tags"
+            "Tags (comma-separated)",
+            value=current_tags,
+            key=f"{selected_team}_{pid_str}_tags",
+            autocomplete="off",
         )
         st.session_state[tags_key] = tag_str
         st.caption("Vinkki: muutama iskevä tagi (esim. 'Press-resistance, Pace, Leader').")
@@ -997,7 +1022,10 @@ def _render_team_editor_flow(selected_team: str, preselected_name: Optional[str]
         with a3:
             st.warning("Type DELETE to confirm deletion from master file", icon="⚠️")
             conf = st.text_input(
-                "Confirmation", key=f"{selected_team}_{pid_str}_del_conf", placeholder="DELETE"
+                "Confirmation",
+                key=f"{selected_team}_{pid_str}_del_conf",
+                placeholder="DELETE",
+                autocomplete="off",
             )
             if st.button(
                 "Delete row from master",

--- a/app/quick_notes_page.py
+++ b/app/quick_notes_page.py
@@ -92,6 +92,7 @@ def show_quick_notes_page() -> None:
             "Search by name",
             key=PAGE_KEY + "search",
             placeholder="Type player name…",
+            autocomplete="off",
         )
         results = _search_players(query)
         labels = [f"{p['name']} ({p.get('current_club') or '—'})" for p in results]
@@ -118,12 +119,14 @@ def show_quick_notes_page() -> None:
     with col_add:
         with st.popover("＋ New Player"):
             with st.form(PAGE_KEY + "add_player_form", clear_on_submit=True):
-                name = st.text_input("Name*", value="")
+                name = st.text_input("Name*", value="", autocomplete="off")
                 colp = st.columns(2)
-                position = colp[0].text_input("Position", value="")
-                current_club = colp[1].text_input("Current club", value="")
+                position = colp[0].text_input("Position", value="", autocomplete="off")
+                current_club = colp[1].text_input(
+                    "Current club", value="", autocomplete="off"
+                )
                 coln = st.columns(2)
-                nationality = coln[0].text_input("Nationality", value="")
+                nationality = coln[0].text_input("Nationality", value="", autocomplete="off")
                 preferred_foot = coln[1].selectbox(
                     "Preferred foot",
                     ["", "Right", "Left", "Both"],

--- a/app/reports_page.py
+++ b/app/reports_page.py
@@ -45,7 +45,12 @@ def render_essential_section() -> dict:
         position = (
             st.selectbox("Position", POSITIONS, index=6, key="reports__pos_dd")
             if use_dd
-            else st.text_input("Position (free text)", value="CM", key="reports__pos_txt")
+            else st.text_input(
+                "Position (free text)",
+                value="CM",
+                key="reports__pos_txt",
+                autocomplete="off",
+            )
         )
 
     c1, c2 = st.columns(2)
@@ -111,12 +116,12 @@ def _load_players() -> List[Dict[str, Any]]:
 
 def render_add_player_form(on_success: Callable | None = None) -> None:
     with st.form(key="players__add_form", border=True):
-        name = st.text_input("Name*", "")
-        position = st.text_input("Position", "")
+        name = st.text_input("Name*", "", autocomplete="off")
+        position = st.text_input("Position", "", autocomplete="off")
         preferred_foot = st.selectbox("Preferred Foot", ["", "Right", "Left", "Both"])
-        nationality = st.text_input("Nationality", "")
-        current_club = st.text_input("Current Club", "")
-        transfermarkt_url = st.text_input("Transfermarkt URL", "")
+        nationality = st.text_input("Nationality", "", autocomplete="off")
+        current_club = st.text_input("Current Club", "", autocomplete="off")
+        transfermarkt_url = st.text_input("Transfermarkt URL", "", autocomplete="off")
 
         submitted = st.form_submit_button("Create Player", use_container_width=True, type="primary")
         if submitted:
@@ -192,9 +197,11 @@ def show_reports_page() -> None:
                 key="reports__selected_player_id",
             )
             report_date = st.date_input("Report date", value=date.today(), key="reports__report_date")
-            competition = st.text_input("Competition", key="reports__competition")
-            opponent = st.text_input("Opponent", key="reports__opponent")
-            location = st.text_input("Location", key="reports__location")
+            competition = st.text_input(
+                "Competition", key="reports__competition", autocomplete="off"
+            )
+            opponent = st.text_input("Opponent", key="reports__opponent", autocomplete="off")
+            location = st.text_input("Location", key="reports__location", autocomplete="off")
 
             st.divider()
             attrs = render_essential_section()
@@ -261,9 +268,19 @@ def show_reports_page() -> None:
 
         c1, c2, c3 = st.columns([2, 2, 1])
         with c1:
-            q_opp = st.text_input("Filter by opponent", placeholder="e.g. Millonarios", key="reports__f_opp")
+            q_opp = st.text_input(
+                "Filter by opponent",
+                placeholder="e.g. Millonarios",
+                key="reports__f_opp",
+                autocomplete="off",
+            )
         with c2:
-            q_comp = st.text_input("Filter by competition", placeholder="e.g. Liga", key="reports__f_comp")
+            q_comp = st.text_input(
+                "Filter by competition",
+                placeholder="e.g. Liga",
+                key="reports__f_comp",
+                autocomplete="off",
+            )
         with c3:
             min_ment = st.slider("MENT ≥", 1, 5, 1, key="reports__f_ment")
 

--- a/app/scout_reporter.py
+++ b/app/scout_reporter.py
@@ -309,8 +309,12 @@ def show_scout_match_reporter():
     matches = list_matches()
     with st.expander("➕ Add Match", expanded=False):
         c1, c2 = st.columns(2)
-        home = c1.text_input("Home Team", key="scout_reporter__home")
-        away = c2.text_input("Away Team", key="scout_reporter__away")
+        home = c1.text_input(
+            "Home Team", key="scout_reporter__home", autocomplete="off"
+        )
+        away = c2.text_input(
+            "Away Team", key="scout_reporter__away", autocomplete="off"
+        )
         mdate = st.date_input("Match Date", date.today(), key="scout_reporter__mdate")
         mtime = st.time_input(
             "Kickoff Time",
@@ -321,9 +325,14 @@ def show_scout_match_reporter():
             "Kickoff timezone",
             st.session_state.get("latam_tz", "America/Bogota"),
             key="scout_reporter__tz",
+            autocomplete="off",
         )
-        comp = st.text_input("Competition (optional)", key="scout_reporter__comp")
-        loc = st.text_input("Location (optional)", key="scout_reporter__loc")
+        comp = st.text_input(
+            "Competition (optional)", key="scout_reporter__comp", autocomplete="off"
+        )
+        loc = st.text_input(
+            "Location (optional)", key="scout_reporter__loc", autocomplete="off"
+        )
         if st.button("Add Match", key="scout_reporter__add_match_btn", type="primary"):
             if home and away:
                 local_dt = datetime.combine(mdate, mtime).replace(tzinfo=ZoneInfo(latam_tz))
@@ -408,7 +417,7 @@ def show_scout_match_reporter():
         st.warning("No players for this selection.")
         return
 
-    q = st.text_input("Search Player", key="scout_reporter__search")
+    q = st.text_input("Search Player", key="scout_reporter__search", autocomplete="off")
     if q:
         ql = q.lower().strip()
         player_opts = [p for p in player_opts if ql in p[1].lower()]
@@ -440,7 +449,9 @@ def show_scout_match_reporter():
 
     position_final = pos_choice
     if pos_choice == "Other / free text":
-        position_free = st.text_input("Position (free text)", key="scout_reporter__pos_free")
+        position_free = st.text_input(
+            "Position (free text)", key="scout_reporter__pos_free", autocomplete="off"
+        )
         position_final = position_free.strip() if position_free else pos_choice
 
     st.markdown("#### Core Areas (1–5) + short notes")
@@ -449,7 +460,12 @@ def show_scout_match_reporter():
     for i, (label, key) in enumerate(CORE_AREAS):
         with (colA if i % 2 == 0 else colB):
             val = st.slider(label, 1, 5, 3, step=1, key=f"scout_reporter__rt_{key}")
-            note = st.text_input(f"Comment – {label}", key=f"scout_reporter__cm_{key}", placeholder="optional")
+            note = st.text_input(
+                f"Comment – {label}",
+                key=f"scout_reporter__cm_{key}",
+                placeholder="optional",
+                autocomplete="off",
+            )
             ratings.append({"attribute": label, "rating": val, "comment": note})
 
     # General comment
@@ -586,6 +602,7 @@ def show_scout_match_reporter():
         text_query = st.text_input(
             "Search (player, match, notes)",
             key="scout_reporter__filter_q",
+            autocomplete="off",
         )
     with f2:
         player_filter = st.multiselect(
@@ -658,7 +675,12 @@ def show_scout_match_reporter():
 
     st.markdown("---")
     st.warning("Type **DELETE** to confirm removals.", icon="⚠️")
-    confirm = st.text_input("Confirmation", placeholder="DELETE to confirm", key="scout_reporter__confirm")
+    confirm = st.text_input(
+        "Confirmation",
+        placeholder="DELETE to confirm",
+        key="scout_reporter__confirm",
+        autocomplete="off",
+    )
 
     cdel1, cdel2, cdel3 = st.columns([1, 1, 3])
     with cdel1:

--- a/app/shortlists.py
+++ b/app/shortlists.py
@@ -128,7 +128,9 @@ def show_shortlists():
             st.info("No shortlists yet. Create one below.")
 
         sel = st.selectbox("Select", list_names or ["—"], index=0 if list_names else 0, key="sl_sel_page")
-        new_nm = st.text_input("New list name", placeholder="e.g. U23 Forwards")
+        new_nm = st.text_input(
+            "New list name", placeholder="e.g. U23 Forwards", autocomplete="off"
+        )
         c1, c2 = st.columns([1, 1])
         if c1.button("Create", type="primary"):
             nn = new_nm.strip()
@@ -145,7 +147,9 @@ def show_shortlists():
 
         # rename
         if sel in shortlists:
-            rn = st.text_input("Rename", value=sel, key="sl_rename")
+            rn = st.text_input(
+                "Rename", value=sel, key="sl_rename", autocomplete="off"
+            )
             if rn.strip() and rn.strip() != sel and st.button("Apply rename", type="primary"):
                 shortlists[rn.strip()] = shortlists.pop(sel)
                 _save_shortlists(shortlists)

--- a/app/shortlists_page.py
+++ b/app/shortlists_page.py
@@ -80,7 +80,7 @@ def show_shortlists_page() -> None:
 
     # create shortlist
     with st.expander("Create new shortlist"):
-        name = st.text_input("Shortlist name", key="shortlists__name")
+        name = st.text_input("Shortlist name", key="shortlists__name", autocomplete="off")
         if st.button("Create", type="primary"):
             if not name.strip():
                 st.warning("Name required.")


### PR DESCRIPTION
## Summary
- disable browser autofill for Streamlit text inputs across data entry pages so only the login form uses autofill

## Testing
- python -m compileall app

------
https://chatgpt.com/codex/tasks/task_e_68d62c3418f48320b2bcbccac639557c