### PR TITLE
Enhance sidebar collapse control styling

### DIFF
--- a/app/styles/sidebar.css
+++ b/app/styles/sidebar.css
@@ -29,6 +29,120 @@
   --sb-width-sm: 260px;
 }
 
+/* ===== Sidebar Collapse Button ===== */
+:where([data-testid="stSidebarCollapseButton"]) {
+  position: fixed;
+  top: 1rem;
+  left: 1rem;
+  z-index: 1300;
+  width: 2.75rem;
+  height: 2.75rem;
+  display: flex;
+  align-items: stretch;
+  justify-content: stretch;
+  padding: 0;
+}
+
+[data-testid="stSidebarCollapseButton"] > button,
+button[data-testid="stSidebarCollapseButton"] {
+  flex: 1 1 auto;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 100%;
+  min-width: 100%;
+  padding: 0;
+  margin: 0;
+  box-sizing: border-box;
+  border-radius: 1.25rem;
+  border: 1px solid color-mix(in oklab, var(--accent-2), black 55%);
+  background: linear-gradient(135deg, color-mix(in oklab, var(--accent), transparent 10%), color-mix(in oklab, var(--accent-2), transparent 6%));
+  color: #f9fbff;
+  box-shadow: 0 10px 26px rgba(59, 130, 246, 0.32), 0 0 0 1px rgba(255, 255, 255, 0.12);
+  cursor: pointer;
+  transition: transform 0.18s ease, box-shadow 0.18s ease, background 0.18s ease, border-color 0.18s ease;
+}
+
+[data-testid="stSidebarCollapseButton"] > button svg,
+button[data-testid="stSidebarCollapseButton"] svg {
+  width: 1.35rem;
+  height: 1.35rem;
+  color: inherit;
+  fill: currentColor;
+  stroke: none;
+}
+
+[data-testid="stSidebarCollapseButton"] > button span,
+button[data-testid="stSidebarCollapseButton"] span {
+  color: inherit;
+}
+
+[data-testid="stSidebarCollapseButton"] > button:hover,
+[data-testid="stSidebarCollapseButton"] > button:focus-visible,
+button[data-testid="stSidebarCollapseButton"]:hover,
+button[data-testid="stSidebarCollapseButton"]:focus-visible {
+  transform: translateY(-1px) scale(1.02);
+  border-color: color-mix(in oklab, var(--accent-2), white 12%);
+  background: linear-gradient(135deg, color-mix(in oklab, var(--accent), transparent 0%), color-mix(in oklab, var(--accent-2), white 8%));
+  box-shadow: 0 12px 28px rgba(99, 102, 241, 0.42), 0 0 0 1px rgba(255, 255, 255, 0.16);
+  outline: none;
+}
+
+[data-testid="stSidebarCollapseButton"] > button:focus-visible,
+button[data-testid="stSidebarCollapseButton"]:focus-visible {
+  box-shadow: 0 0 0 3px rgba(99, 102, 241, 0.28), 0 0 0 1px rgba(255, 255, 255, 0.24);
+}
+
+:where([data-testid="stSidebarCollapseButton"])::after,
+:where(button[data-testid="stSidebarCollapseButton"]::after) {
+  content: "";
+  position: absolute;
+  left: calc(100% + 0.75rem);
+  top: 50%;
+  transform: translateY(-50%) translateX(-4px);
+  padding: 0.2rem 0.6rem;
+  border-radius: 999px;
+  font-size: 0.72rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  background: var(--bg-elev);
+  color: var(--ink);
+  border: 1px solid color-mix(in oklab, var(--border), white 10%);
+  box-shadow: var(--shadow);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.18s ease, transform 0.18s ease;
+  white-space: nowrap;
+}
+
+:where(section[data-testid="stSidebar"][aria-expanded="false"] [data-testid="stSidebarCollapseButton"])::after,
+:where(button[data-testid="stSidebarCollapseButton"][data-sb-collapsed="true"]::after) {
+  content: "Menu";
+  opacity: 1;
+  transform: translateY(-50%) translateX(0);
+}
+
+:where(body .stSidebarCollapsedControl [data-testid="stSidebarCollapseButton"]) {
+  left: 0.9rem;
+}
+
+@media (max-width: 768px) {
+  :where([data-testid="stSidebarCollapseButton"]) {
+    top: 0.75rem;
+    left: 0.75rem;
+    width: 2.85rem;
+    height: 2.85rem;
+  }
+
+  :where([data-testid="stSidebarCollapseButton"]::after),
+  :where(button[data-testid="stSidebarCollapseButton"]::after) {
+    left: calc(100% + 0.6rem);
+    font-size: 0.68rem;
+  }
+}
+
 /* ===== Sidebar ===== */
 :where(section[data-testid="stSidebar"]) {
   background: radial-gradient(1200px 600px at 15% -10%, rgba(255,255,255,.03), transparent 60%), var(--bg);


### PR DESCRIPTION
## Summary
- restyle the Streamlit sidebar collapse control with a fixed accent button that fills a 44px hitbox and layers above the sidebar edge
- provide hover/focus states and a responsive label that appears when the sidebar is collapsed on both wide and narrow layouts
- ensure the new styling covers both historical button markup and the current div-wrapper markup Streamlit emits

## Testing
- `streamlit run app/app.py --server.headless true`

------
https://chatgpt.com/codex/tasks/task_e_68d632c13f8883209d5e6f253c4910d7