### PR TITLE
Restyle sidebar collapse button

### DIFF
--- a/app/styles/sidebar.css
+++ b/app/styles/sidebar.css
@@ -55,13 +55,36 @@ button[data-testid="stSidebarCollapseButton"] {
   padding: 0;
   margin: 0;
   box-sizing: border-box;
+  position: relative;
+  overflow: hidden;
   border-radius: 1.25rem;
-  border: 1px solid color-mix(in oklab, var(--accent-2), black 55%);
-  background: linear-gradient(135deg, color-mix(in oklab, var(--accent), transparent 10%), color-mix(in oklab, var(--accent-2), transparent 6%));
-  color: #f9fbff;
-  box-shadow: 0 10px 26px rgba(59, 130, 246, 0.32), 0 0 0 1px rgba(255, 255, 255, 0.12);
+  border: 1px solid color-mix(in oklab, var(--accent-2), black 65%);
+  background: linear-gradient(160deg,
+    color-mix(in oklab, var(--bg-elev), white 8%),
+    color-mix(in oklab, var(--bg-soft), black 5%));
+  color: color-mix(in oklab, var(--ink), white 6%);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.06),
+    0 10px 24px rgba(12, 16, 24, 0.45);
+  backdrop-filter: blur(12px);
   cursor: pointer;
-  transition: transform 0.18s ease, box-shadow 0.18s ease, background 0.18s ease, border-color 0.18s ease;
+  transition:
+    transform 0.2s ease,
+    box-shadow 0.2s ease,
+    border-color 0.2s ease,
+    color 0.2s ease;
+}
+
+[data-testid="stSidebarCollapseButton"] > button::before,
+button[data-testid="stSidebarCollapseButton"]::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at 30% 30%, rgba(99, 102, 241, 0.36), transparent 55%),
+    radial-gradient(circle at 70% 70%, rgba(59, 130, 246, 0.4), transparent 60%);
+  opacity: 0.45;
+  pointer-events: none;
+  transition: opacity 0.2s ease;
 }
 
 [data-testid="stSidebarCollapseButton"] > button svg,
@@ -82,11 +105,20 @@ button[data-testid="stSidebarCollapseButton"] span {
 [data-testid="stSidebarCollapseButton"] > button:focus-visible,
 button[data-testid="stSidebarCollapseButton"]:hover,
 button[data-testid="stSidebarCollapseButton"]:focus-visible {
-  transform: translateY(-1px) scale(1.02);
-  border-color: color-mix(in oklab, var(--accent-2), white 12%);
-  background: linear-gradient(135deg, color-mix(in oklab, var(--accent), transparent 0%), color-mix(in oklab, var(--accent-2), white 8%));
-  box-shadow: 0 12px 28px rgba(99, 102, 241, 0.42), 0 0 0 1px rgba(255, 255, 255, 0.16);
+  transform: translateY(-1px) scale(1.04);
+  border-color: color-mix(in oklab, var(--accent-2), white 20%);
+  color: color-mix(in oklab, var(--ink), white 12%);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.08),
+    0 14px 30px rgba(37, 99, 235, 0.55);
   outline: none;
+}
+
+[data-testid="stSidebarCollapseButton"] > button:hover::before,
+button[data-testid="stSidebarCollapseButton"]:hover::before,
+[data-testid="stSidebarCollapseButton"] > button:focus-visible::before,
+button[data-testid="stSidebarCollapseButton"]:focus-visible::before {
+  opacity: 0.65;
 }
 
 [data-testid="stSidebarCollapseButton"] > button:focus-visible,
@@ -107,10 +139,10 @@ button[data-testid="stSidebarCollapseButton"]:focus-visible {
   font-weight: 600;
   letter-spacing: 0.04em;
   text-transform: uppercase;
-  background: var(--bg-elev);
-  color: var(--ink);
-  border: 1px solid color-mix(in oklab, var(--border), white 10%);
-  box-shadow: var(--shadow);
+  background: color-mix(in oklab, var(--bg-elev), black 10%);
+  color: color-mix(in oklab, var(--ink), white 4%);
+  border: 1px solid color-mix(in oklab, var(--border), white 14%);
+  box-shadow: 0 18px 38px rgba(12, 16, 24, 0.6);
   opacity: 0;
   pointer-events: none;
   transition: opacity 0.18s ease, transform 0.18s ease;
@@ -123,10 +155,14 @@ button[data-testid="stSidebarCollapseButton"]:focus-visible {
   content: "Menu";
   opacity: 1;
   transform: translateY(-50%) translateX(0);
-  background: linear-gradient(135deg, color-mix(in oklab, var(--accent), transparent 0%), color-mix(in oklab, var(--accent-2), transparent 10%));
-  border-color: color-mix(in oklab, var(--accent-2), black 45%);
-  color: #f9fbff;
-  box-shadow: 0 12px 28px rgba(99, 102, 241, 0.42), 0 0 0 1px rgba(255, 255, 255, 0.16);
+  background: linear-gradient(150deg,
+      color-mix(in oklab, var(--accent), transparent 10%),
+      color-mix(in oklab, var(--accent-2), transparent 6%));
+  border-color: color-mix(in oklab, var(--accent-2), black 35%);
+  color: color-mix(in oklab, #f9fbff, white 4%);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.16),
+    0 16px 34px rgba(99, 102, 241, 0.48);
 }
 
 :where(body .stSidebarCollapsedControl [data-testid="stSidebarCollapseButton"]) {


### PR DESCRIPTION
## Summary
- refresh the sidebar collapse button styling with a frosted gradient look
- add hover and focus treatments for the button glow and label pill

## Testing
- streamlit run app/app.py --server.headless true --server.port 8501

------
https://chatgpt.com/codex/tasks/task_e_68d799dde4008320abe39f9f84406e39