### PR TITLE
Enforce mandatory quick note content validation

### DIFF
--- a/app/quick_notes_page.py
+++ b/app/quick_notes_page.py
@@ -486,8 +486,8 @@ def _note_form(
         if not payload["player_id"]:
             set_toast("Pelaaja on pakollinen.", "warning")
             return
-        if not payload["title"] and not payload["content"]:
-            set_toast("Otsikko tai sisältö vaaditaan.", "warning")
+        if not payload["content"]:
+            set_toast("Muistiinpanon sisältö on pakollinen.", "warning")
             return
         if on_submit(payload):
             st.rerun()


### PR DESCRIPTION
## Summary
- prevent quick note submissions when the content field is blank to match backend validation
- update the warning copy to clearly state that note content is required

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69140296653c832095ca9992daa36621)